### PR TITLE
EXT-971: validate pull request titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          allowed_prefixes: 'EXT-'
+          regex: '^EXT-\d+:\s.+$'


### PR DESCRIPTION
## What?

This PR validates pull request titles.

## Why?

This helps keeping the convention of pull request titles.