### PR TITLE
EXT-1036: Watch mode for @storyblok/field-plugin

### DIFF
--- a/packages/field-plugin/package.json
+++ b/packages/field-plugin/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "check:types": "tsc --noEmit",
-    "build": "vite build && tsc --declaration --emitDeclarationOnly"
+    "dev": "vite build --watch",
+    "build": "vite build"
   },
   "devDependencies": {
     "@types/jest": "*",


### PR DESCRIPTION
## What?
For `@storyblok/field-plugin`:

1. Adds a `dev` command for running the build in development/watch mode.
2. in the `build` command, removed uneccesary `tsc` invocation, because the `vite-plugin-dts` vite plugin takes care of declarion file output. 

## Why

Will be possible to link demo, container and other future examples, and receive updates from the `@storyblok/field-plugin` package via HMR.

## How to test? 

```shell
yarn workspace @storyblok/field-plugin run dev
```