### PR TITLE
EXT-1119: remove build process from deploy command

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -65,9 +65,6 @@ export const deploy: DeployFunc = async ({
     ? resolve(rootPackagePath, packageName)
     : rootPackagePath
 
-  console.log(bold(cyan(`[info] Building \`${packageName}\`...`)))
-  await buildPackage(packagePath)
-
   const defaultOutputPath = resolve(packagePath, 'dist', 'index.js')
 
   const outputPath = output ? resolve(output) : defaultOutputPath
@@ -269,21 +266,4 @@ const isBuildable = (path: string) => {
   }
 
   return true
-}
-
-const buildPackage = async (path: string): Promise<void> => {
-  try {
-    console.log(
-      (
-        await runCommand(`yarn build`, {
-          cwd: path,
-        })
-      ).stdout,
-    )
-    console.log('')
-  } catch (err) {
-    console.log((err as Error).message)
-    console.log(red('[ERROR]'), 'Build failed.')
-    process.exit(1)
-  }
 }

--- a/packages/cli/templates/monorepo/package.json
+++ b/packages/cli/templates/monorepo/package.json
@@ -12,7 +12,6 @@
     "test": "yarn workspace ${0} test",
     "test:watch": "yarn workspace ${0} test:watch",
     "new": "field-plugin add --dir \"./packages\"",
-    "deploy": "field-plugin deploy --chooseFrom \"./packages\"",
     "lint": "eslint --ext .js,.vue .",
     "format": "prettier . --write"
   },

--- a/packages/cli/templates/vue2/package.json.mustache
+++ b/packages/cli/templates/vue2/package.json.mustache
@@ -8,7 +8,7 @@
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "deploy": "field-plugin deploy"
+    "deploy": "npm run build && field-plugin deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "file:./storyblok-field-plugin-0.0.1-alpha.0.tgz",


### PR DESCRIPTION
## What?

This PR removes the `yarn build` from `deploy` command. It may differ from project to project. Instead of removing it from the deploy command, we're now putting it in the package.json, so that anyone can tweak it as they want.


## Why?

[EXT-1119](https://storyblok.atlassian.net/browse/EXT-1119)



[EXT-1119]: https://storyblok.atlassian.net/browse/EXT-1119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ