### PR TITLE
EXT-1131: add --name to deploy command

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -49,6 +49,10 @@ export const main = () => {
     .description('deploys your selected plugin to Storyblok')
     .option('--token <value>', 'Storyblok personal access token')
     .option('--skipPrompts', 'deploys without prompts', false)
+    .option(
+      '--name <value>',
+      'name of plugin (Lowercase alphanumeric and dash)',
+    )
     .addOption(
       new Option(
         '--output <value>',

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -18,7 +18,7 @@ export const runCommand: RunCommandFunc = async (command, options) => {
 }
 
 //TODO testing
-export const validateToken = (token?: string): string | undefined => {
+export const validateToken = (token?: string): string | null => {
   if (typeof token !== 'undefined' && token !== '') {
     return token
   }
@@ -30,20 +30,23 @@ export const validateToken = (token?: string): string | undefined => {
     return process.env.STORYBLOK_PERSONAL_ACCESS_TOKEN
   }
 
-  console.log(red('[ERROR]'), 'Token to access Storyblok is undefined.')
-  console.log(
-    'Please provide a valid --token option value or STORYBLOK_PERSONAL_ACCESS_TOKEN as an environmental variable',
-  )
-  process.exit(1)
+  return null
 }
 
-export const promptName = async (message: string): Promise<string | never> => {
+export const promptName = async ({
+  message,
+  initialValue,
+}: {
+  message: string
+  initialValue?: string
+}): Promise<string | never> => {
   const { name } = (await prompts(
     [
       {
         type: 'text',
         name: 'name',
         message,
+        initial: initialValue,
         validate: (name: string) => new RegExp(/^[a-z0-9\\-]+$/).test(name),
       },
     ],


### PR DESCRIPTION
## What?

This PR adds `--name` option to `deploy` command.

## Why?

This command may be used in different path, so inferring the package name from `package.json` shouldn't be the default behavior.

## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->