### PR TITLE
EXT-1175: fix add command in the monorepo template

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -86,10 +86,15 @@ export const main = () => {
       'name of plugin (Lowercase alphanumeric and dash)',
     )
     .option('--dir <value>', 'directory to create a field-plugin into', '.')
+    .addOption(
+      new Option('--structure <value>', 'setup structure').choices(
+        structureOptions,
+      ),
+    )
     .action(async function (this: Command) {
-      const { name, template, dir } = this.opts<AddArgs>()
+      const { name, template, dir, structure } = this.opts<AddArgs>()
 
-      await add({ name, template, dir })
+      await add({ name, template, dir, structure })
     })
 
   program.parse(process.argv)

--- a/packages/cli/templates/monorepo/package.json
+++ b/packages/cli/templates/monorepo/package.json
@@ -11,7 +11,7 @@
     "build": "yarn workspace ${0} build",
     "test": "yarn workspace ${0} test",
     "test:watch": "yarn workspace ${0} test:watch",
-    "new": "field-plugin add --dir \"./packages\"",
+    "new": "field-plugin add --dir \"./packages\" --structure monorepo",
     "lint": "eslint --ext .js,.vue .",
     "format": "prettier . --write"
   },


### PR DESCRIPTION
## What?

This PR fixes `add` command to be run in `multiple` mode inside the monorepo template.

## Why?
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->