### PR TITLE
EXT-1179: Simplify Select Asset Action

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -127,7 +127,7 @@ export const createPluginActions: CreatePluginActions = (
       },
       selectAsset: (callback) => {
         assetSelectedCallbackRef = callback
-        postToContainer(assetModalChangeMessage(uid, ''))
+        postToContainer(assetModalChangeMessage(uid))
       },
       setPluginReady,
       requestContext: () => postToContainer(getContextMessage(uid)),

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/AssetSelectedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/AssetSelectedMessage.test.ts
@@ -31,19 +31,22 @@ describe('AssetSelectedMessage', function () {
     })
   })
   describe('the field property', () => {
-    it('is required', () => {
+    it('is optional', () => {
       expect(
         isAssetSelectedMessage({
-          ...stub,
-          field: 'any-string',
+          action: 'asset-selected',
+          uid: '-preview',
+          filename: 'https://somthing.com/myimage.jpg',
         }),
       ).toBeTruthy()
+    })
+    it('can be undefined', () => {
       expect(
         isAssetSelectedMessage({
           ...stub,
           field: undefined,
         }),
-      ).toBeFalsy()
+      ).toBeTruthy()
     })
     it('is a string', () => {
       expect(
@@ -62,12 +65,6 @@ describe('AssetSelectedMessage', function () {
         isAssetSelectedMessage({
           ...stub,
           field: null,
-        }),
-      ).toBeFalsy()
-      expect(
-        isAssetSelectedMessage({
-          ...stub,
-          field: undefined,
         }),
       ).toBeFalsy()
       expect(

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/AssetSelectedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/AssetSelectedMessage.ts
@@ -3,7 +3,7 @@ import { hasKey } from '../../../utils'
 
 //TODO: tests
 export type AssetSelectedMessage = MessageToPlugin<'asset-selected'> & {
-  field: string
+  field?: string
   filename: string
 }
 
@@ -12,7 +12,14 @@ export const isAssetSelectedMessage = (
 ): obj is AssetSelectedMessage =>
   isMessageToPlugin(obj) &&
   obj.action === 'asset-selected' &&
-  hasKey(obj, 'field') &&
-  typeof obj.field === 'string' &&
   hasKey(obj, 'filename') &&
-  typeof obj.filename === 'string'
+  typeof obj.filename === 'string' &&
+  hasField(obj)
+
+export const hasField = (obj: unknown) => {
+  if (!hasKey(obj, 'field') || typeof obj.field === 'undefined') {
+    // field is either omitted or set to undefined
+    return true
+  }
+  return typeof obj.field === 'string'
+}

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/AssetModalChangeMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/AssetModalChangeMessage.test.ts
@@ -25,20 +25,38 @@ describe('AssetModalChangeMessage', () => {
       ).toBeFalsy()
       expect(isAssetModalChangeMessage({ ...stub, event: null })).toBeFalsy()
     })
-    it('should include field that is of type string', () => {
-      expect(isAssetModalChangeMessage(stub)).toBeTruthy()
-      expect(isAssetModalChangeMessage({ ...stub, field: 1 })).toBeFalsy()
-      expect(
-        isAssetModalChangeMessage({ ...stub, field: undefined }),
-      ).toBeFalsy()
-      expect(isAssetModalChangeMessage({ ...stub, field: null })).toBeFalsy()
+    describe('field property', () => {
+      it('is optional', () => {
+        expect(
+          isAssetModalChangeMessage({
+            action: 'plugin-changed',
+            uid,
+            event: 'showAssetModal',
+          }),
+        ).toBeTruthy()
+      })
+      it('can be undefined', () => {
+        expect(
+          isAssetModalChangeMessage({ ...stub, field: undefined }),
+        ).toBeTruthy()
+      })
+      it('is a string', () => {
+        expect(
+          isAssetModalChangeMessage({ ...stub, field: 'any-string' }),
+        ).toBeTruthy()
+        expect(isAssetModalChangeMessage({ ...stub, field: 1 })).toBeFalsy()
+        expect(isAssetModalChangeMessage({ ...stub, field: null })).toBeFalsy()
+      })
     })
   })
   describe('constructor', () => {
     it('includes the uid', () => {
       expect(assetModalChangeMessage(uid, field)).toHaveProperty('uid', uid)
     })
-    it('includes the field', () => {
+    test('that the field is optional', () => {
+      expect(assetModalChangeMessage(uid)).not.toHaveProperty('field', field)
+    })
+    test('that if set, the field is included', () => {
       expect(assetModalChangeMessage(uid, field)).toHaveProperty('field', field)
     })
   })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/AssetModalChangeMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/AssetModalChangeMessage.ts
@@ -2,20 +2,27 @@ import { isMessageToContainer, MessageToContainer } from './MessageToContainer'
 import { hasKey } from '../../../utils'
 
 export type AssetModalChangeMessage = MessageToContainer<'showAssetModal'> & {
-  field: string
+  field?: string
 }
 
 export const isAssetModalChangeMessage = (
   obj: unknown,
 ): obj is AssetModalChangeMessage =>
-  isMessageToContainer(obj) &&
-  obj.event === 'showAssetModal' &&
-  hasKey(obj, 'field') &&
-  typeof obj.field === 'string'
+  isMessageToContainer(obj) && obj.event === 'showAssetModal' && hasField(obj)
+
+const hasField = (
+  obj: unknown,
+): obj is Pick<AssetModalChangeMessage, 'field'> => {
+  if (!hasKey(obj, 'field') || typeof obj.field === 'undefined') {
+    // field is either omitted or set to undefined
+    return true
+  }
+  return typeof obj.field === 'string'
+}
 
 export const assetModalChangeMessage = (
   uid: string,
-  field: string,
+  field?: string,
 ): AssetModalChangeMessage => ({
   action: 'plugin-changed',
   event: 'showAssetModal',


### PR DESCRIPTION
## What?

How it worked before this PR:

When you open the asset selector, the plugin would store a reference to an object `assetSelectedCallbackRef` with 1) a `callback` function that will be called once an asset had been selected, and 2) a `uid`. The unique id would be passed to the asset selector in the `field` property.

When an asset is selected, the field property is passed along with the selected filename. The library would compare the uid in the message (stored in the field property) with the uid in the reference. Only if they matched would the callback function be called.

The idea was that this would guarantee that message from the visual editor correspond to the same action that the user initiated.

This pull request removes the `uid` check.

## Why?

The `uid` check is

- Overly complex
- Making it slightly more difficult to test `createPluginActions`

I think this mechanism with the uid comparison was overdoing it. When the asset selector is opened, the user is blocked from performing any other actions in the field plugin, so there is really no risk that the wrong callback function will be called.

Furhermore, this functionality makes the `createPluginActions` function more complicated to test the asset select functionality in `createPluginActions`. Because with this funcionality, in the test, we'd have to intercept the generated `uid` and pass it back to onAssetSelect. Without the uid, we can simply call onAssetSelect with the `filename`, and not bother with the `field` property.
