### PR TITLE
EXT-1180: Call setPluginReady in createFieldPlugin

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -107,7 +107,6 @@ export const createPluginActions: CreatePluginActions = (
 
   // Receive the current value
   const setPluginReady = () => postToContainer(pluginLoadedMessage(uid))
-  setPluginReady()
   return {
     actions: {
       setHeight: (height) => {


### PR DESCRIPTION
## What?

Removes the call to `setPluginReady` in `createPluginActions` -- it is already called in `createFieldPlugin`.

## Why?

`setPluginReady` requests the initial state from the container (value, spaceId, language, etc).

This only need to be done once.

It also seems more intuitive to call it in `createFieldPlugin` rather than `createPluginActions`, because `createPluginActions` is just a constructor function that provides the means to send plugin messages via the returned `actions` object, but shouldn't do it unless implicitly.
