### PR TITLE
chore: remove code that is no longer relevant

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,6 +1,6 @@
 import { bold, cyan, red, green } from 'kleur/colors'
 import prompts from 'prompts'
-import { resolve, dirname, basename } from 'path'
+import { resolve, dirname } from 'path'
 import {
   existsSync,
   mkdirSync,


### PR DESCRIPTION
## What?

This PR removes a block of code that is no longer relevant since #63 

## Why?

Now `yarn.lock` doesn't exist in templates, so we should remove this.

## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->