### PR TITLE
EXT-1197: Simplify FieldPluginResponse Type

### DIFF
--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -14,9 +14,9 @@ export type PluginComponent = FunctionComponent<{
 }>
 
 export const FieldPluginDemo: FunctionComponent = () => {
-  const { isLoading, error, data, actions } = useFieldPlugin()
+  const { type, data, actions } = useFieldPlugin()
 
-  if (isLoading) {
+  if (type === 'loading') {
     return (
       <Box>
         <LoadingIcon />
@@ -24,7 +24,7 @@ export const FieldPluginDemo: FunctionComponent = () => {
       </Box>
     )
   }
-  if (error) {
+  if (type === 'error') {
     return (
       <Box>
         <SquareErrorIcon />

--- a/packages/demo/src/useFieldPlugin.ts
+++ b/packages/demo/src/useFieldPlugin.ts
@@ -5,7 +5,7 @@ type UseFieldPlugin = () => FieldPluginResponse
 
 export const useFieldPlugin: UseFieldPlugin = () => {
   const [state, setState] = useState<FieldPluginResponse>(() => ({
-    isLoading: true,
+    type: 'loading',
   }))
 
   useEffect(() => {

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
@@ -3,19 +3,19 @@ import { PluginActions } from './PluginActions'
 
 export type FieldPluginResponse =
   | {
-      isLoading: true
+      type: 'loading'
       error?: never
       data?: never
       actions?: never
     }
   | {
-      isLoading: false
+      type: 'error'
       error: Error
       data?: never
       actions?: never
     }
   | {
-      isLoading: false
+      type: 'loaded'
       error?: never
       data: PluginState
       actions: PluginActions

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -17,8 +17,8 @@ export const createFieldPlugin: CreateFieldPlugin = (onUpdateState) => {
 
   if (!isEmbedded) {
     onUpdateState({
+      type: 'error',
       error: new Error(`The window is not embedded within another window`),
-      isLoading: false,
     })
     return () => undefined
   }
@@ -27,10 +27,10 @@ export const createFieldPlugin: CreateFieldPlugin = (onUpdateState) => {
 
   if (!params) {
     onUpdateState({
+      type: 'error',
       error: new Error(
         `The URL parameters does not match the expected format.`,
       ),
-      isLoading: false,
     })
     return () => undefined
   }
@@ -54,7 +54,7 @@ export const createFieldPlugin: CreateFieldPlugin = (onUpdateState) => {
     postToContainer,
     (data) => {
       onUpdateState({
-        isLoading: false,
+        type: 'loaded',
         data,
         actions,
       })


### PR DESCRIPTION
## What?

Simplified the `FieldPluginResponse` type.  Now, it can be one of three types: `loading`, `error`, `loaded`.

## Why?

 This will make it easier for components to render conditionally, because they will only have to check `response.type === 'loaded'`, instead of checking both `isLoading` and `error`.
