### PR TITLE
EXT-1232: change selectAsset to return a Promise

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/PluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/PluginActions.ts
@@ -3,7 +3,7 @@ export type SetValue = (value: unknown) => void
 export type SetModalOpen = (isModal: boolean) => void
 export type SetPluginReady = () => void
 export type RequestContext = () => void
-export type SelectAsset = (callback: (filename: string) => void) => void
+export type SelectAsset = () => Promise<string>
 
 export type PluginActions = {
   setHeight: SetHeight

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
@@ -183,22 +183,21 @@ describe('createPluginActions', () => {
       const {
         actions: { selectAsset },
       } = createPluginActions(uid, postToContainer, onUpdateState)
-      const onAssetSelected = jest.fn()
-      selectAsset(onAssetSelected)
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      selectAsset()
       expect(postToContainer).toHaveBeenLastCalledWith(
         expect.objectContaining({
           event: 'showAssetModal',
         } satisfies Partial<AssetModalChangeMessage>),
       )
     })
-    it('calls the callback function when an asset has been selected by the user', () => {
+    it('calls the callback function when an asset has been selected by the user', async () => {
       const { uid, postToContainer, onUpdateState } = mock()
       const {
         actions: { selectAsset },
         messageCallbacks: { onAssetSelect },
       } = createPluginActions(uid, postToContainer, onUpdateState)
-      const onAssetSelected = jest.fn()
-      selectAsset(onAssetSelected)
+      const promise = selectAsset()
       const filename = 'hello.jpg'
       onAssetSelect({
         uid,
@@ -206,7 +205,8 @@ describe('createPluginActions', () => {
         field: 'dummy',
         filename,
       })
-      expect(onAssetSelected).toHaveBeenCalledWith(filename)
+      const result = await promise
+      expect(result).toEqual(filename)
     })
   })
 })

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -124,9 +124,11 @@ export const createPluginActions: CreatePluginActions = (
         }
         onUpdateState(state)
       },
-      selectAsset: (callback) => {
-        assetSelectedCallbackRef = callback
-        postToContainer(assetModalChangeMessage(uid))
+      selectAsset: () => {
+        return new Promise((resolve) => {
+          assetSelectedCallbackRef = resolve
+          postToContainer(assetModalChangeMessage(uid))
+        })
       },
       setPluginReady,
       requestContext: () => postToContainer(getContextMessage(uid)),


### PR DESCRIPTION
## What?

This PR changes `selectAsset` to return a Promise, instead of taking a callback function.

## Why?

`selectAsset` is an asynchronous function, and having it returning a Promise will most likely improve DX for many of those who write with async/await syntaxes.