### PR TITLE
EXT-1238: update templates to the latest library version

### DIFF
--- a/packages/cli/templates/js/package.json
+++ b/packages/cli/templates/js/package.json
@@ -10,7 +10,7 @@
     "check:types": "tsc --noEmit"
   },
   "dependencies": {
-    "@storyblok/field-plugin": "workspace:*"
+    "@storyblok/field-plugin": "0.0.1-alpha.2"
   },
   "devDependencies": {
     "eslint": "latest",

--- a/packages/cli/templates/react/package.json
+++ b/packages/cli/templates/react/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@storyblok/field-plugin": "0.0.1-alpha.1",
+    "@storyblok/field-plugin": "0.0.1-alpha.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/cli/templates/react/src/components/AssetSelector.tsx
+++ b/packages/cli/templates/react/src/components/AssetSelector.tsx
@@ -8,8 +8,8 @@ type AssetSelectorFunc = FunctionComponent<{
 const AssetSelector: AssetSelectorFunc = ({selectAsset}) => {
     const [imageUrl, setImageUrl] = useState<string>('')
 
-    const handleSelectAsset = () => {
-        selectAsset((filename: string) => setImageUrl(filename))
+    const handleSelectAsset = async () => {
+        setImageUrl(await selectAsset())
     }
 
     return (

--- a/packages/cli/templates/vue2/package.json
+++ b/packages/cli/templates/vue2/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"
   },
   "dependencies": {
-    "@storyblok/field-plugin": "0.0.1-alpha.1",
+    "@storyblok/field-plugin": "0.0.1-alpha.2",
     "joi": "^17.7.0",
     "vue": "^2.7.14"
   },

--- a/packages/cli/templates/vue2/src/components/AssetSelector.vue
+++ b/packages/cli/templates/vue2/src/components/AssetSelector.vue
@@ -28,10 +28,8 @@ export default {
     }
   },
   methods: {
-    handleSelectAsset() {
-      this.selectAsset((filename) => {
-        this.imageUrl = filename
-      })
+    async handleSelectAsset() {
+      this.imageUrl = await this.selectAsset()
     },
   },
 }

--- a/packages/cli/templates/vue3/package.json
+++ b/packages/cli/templates/vue3/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@storyblok/field-plugin": "0.0.1-alpha.1",
+    "@storyblok/field-plugin": "0.0.1-alpha.2",
     "vue": "^3.2.47"
   },
   "devDependencies": {

--- a/packages/cli/templates/vue3/src/components/AssetSelector.vue
+++ b/packages/cli/templates/vue3/src/components/AssetSelector.vue
@@ -9,8 +9,8 @@ const props = defineProps<{
 
 const imageUrl = ref('')
 
-const handleSelectAsset = () => {
-  props.selectAsset((filename) => (imageUrl.value = filename))
+const handleSelectAsset = async () => {
+  imageUrl.value = await props.selectAsset()
 }
 </script>
 

--- a/packages/demo/src/components/AssetSelector.tsx
+++ b/packages/demo/src/components/AssetSelector.tsx
@@ -43,9 +43,7 @@ export const AssetSelector: PluginComponent = (props) => {
       ) : (
         <Button
           startIcon={<AssetIcon />}
-          onClick={() =>
-            actions.selectAsset((filename) => setImageUrl(filename))
-          }
+          onClick={async () => setImageUrl(await actions.selectAsset())}
         >
           Select Asset
         </Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1829,14 +1829,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storyblok/field-plugin@npm:0.0.1-alpha.1":
-  version: 0.0.1-alpha.1
-  resolution: "@storyblok/field-plugin@npm:0.0.1-alpha.1"
-  checksum: 5b455d68d43cb138ef6356d04b534557b6351293e4301bddcf1e4d0f5398ca808d53c49cd4256ce5d43524cfd980af7f420938936ed2cc9a75720b9963bbbe34
-  languageName: node
-  linkType: hard
-
-"@storyblok/field-plugin@workspace:*, @storyblok/field-plugin@workspace:packages/field-plugin":
+"@storyblok/field-plugin@0.0.1-alpha.2, @storyblok/field-plugin@workspace:*, @storyblok/field-plugin@workspace:packages/field-plugin":
   version: 0.0.0-use.local
   resolution: "@storyblok/field-plugin@workspace:packages/field-plugin"
   dependencies:
@@ -4787,7 +4780,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "field-plugin-react-template@workspace:packages/cli/templates/react"
   dependencies:
-    "@storyblok/field-plugin": 0.0.1-alpha.1
+    "@storyblok/field-plugin": 0.0.1-alpha.2
     "@types/react": ^18.0.28
     "@types/react-dom": ^18.0.11
     "@typescript-eslint/eslint-plugin": latest
@@ -4807,7 +4800,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "field-plugin-vue2-template@workspace:packages/cli/templates/vue2"
   dependencies:
-    "@storyblok/field-plugin": 0.0.1-alpha.1
+    "@storyblok/field-plugin": 0.0.1-alpha.2
     "@vitejs/plugin-vue2": 2.2.0
     joi: ^17.7.0
     vite: 4.0.4
@@ -4820,7 +4813,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "field-plugin-vue3-template@workspace:packages/cli/templates/vue3"
   dependencies:
-    "@storyblok/field-plugin": 0.0.1-alpha.1
+    "@storyblok/field-plugin": 0.0.1-alpha.2
     "@vitejs/plugin-vue": ^4.1.0
     typescript: ^4.9.3
     vite: ^4.2.0
@@ -6334,7 +6327,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "js@workspace:packages/cli/templates/js"
   dependencies:
-    "@storyblok/field-plugin": "workspace:*"
+    "@storyblok/field-plugin": 0.0.1-alpha.2
     eslint: latest
     vite: 4.1.4
     vite-plugin-css-injected-by-js: 2.4.0


### PR DESCRIPTION
## What?

This PR updates the templates to use `@storyblok/field-plugin@0.0.1-alpha.2` and updates all the usage of `selectAsset` because of #93.
