### PR TITLE
EXT-1246: Set tsconfig.compilerOptions.allowJs to true

### DIFF
--- a/packages/cli/templates/react/tsconfig.json
+++ b/packages/cli/templates/react/tsconfig.json
@@ -7,7 +7,7 @@
       "DOM.Iterable",
       "ESNext"
     ],
-    "allowJs": false,
+    "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## What?

Set tsconfig.compilerOptions.allowJs to true

## Why?

To allow for JavaScript by default. It will make it easier for non-TypeScript developers to make the switch to JavaScript

## How to test? (optional)

Rename `src/App.tsx` to `src/App.jsx`. Run

```shell
yarn workspace field-plugin-react-template run build     
```