### PR TITLE
EXT-1247: Format React Starter With Prettier

### DIFF
--- a/packages/cli/templates/react/.eslintrc.cjs
+++ b/packages/cli/templates/react/.eslintrc.cjs
@@ -1,35 +1,32 @@
 module.exports = {
-    "root": true,
-    "globals": {
-        "React": true,
-        "JSX": true
+  root: true,
+  globals: {
+    React: true,
+    JSX: true,
+  },
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  settings: {
+    react: {
+      version: 'detect',
     },
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "settings": {
-        "react": {
-            "version": "detect"
-        },
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/recommended"
-    ],
-    "overrides": [],
-    "parser": "@typescript-eslint/parser",
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  overrides: [],
+  parser: '@typescript-eslint/parser',
 
-    "parserOptions": {
-        "tsconfigRootDir": __dirname,
-        "ecmaVersion": "latest",
-        "sourceType": "module",
-        "project": ["./tsconfig.json", "./tsconfig.node.json"]
-    },
-    "plugins": [
-        "react",
-        "@typescript-eslint"
-    ],
-    "rules": {}
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    project: ['./tsconfig.json', './tsconfig.node.json'],
+  },
+  plugins: ['react', '@typescript-eslint'],
+  rules: {},
 }

--- a/packages/cli/templates/react/index.html
+++ b/packages/cli/templates/react/index.html
@@ -1,12 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
     <title>Storyblok Field Plugin</title>
-</head>
-<body>
-<div id="plugin"></div>
-<script type="module" src="/src/main.tsx"></script>
-</body>
+  </head>
+  <body>
+    <div id="plugin"></div>
+    <script
+      type="module"
+      src="/src/main.tsx"
+    ></script>
+  </body>
 </html>

--- a/packages/cli/templates/react/src/App.tsx
+++ b/packages/cli/templates/react/src/App.tsx
@@ -1,26 +1,35 @@
-import {useFieldPlugin} from './useFieldPlugin'
+import { useFieldPlugin } from './useFieldPlugin'
 import Counter from './components/Counter'
 import ModalToggle from './components/ModalToggle'
 import AssetSelector from './components/AssetSelector'
 
 function App() {
-    const {type, data, actions} = useFieldPlugin()
+  const { type, data, actions } = useFieldPlugin()
 
-    if (type === 'loading') {
-        return <span>Loading...</span>
-    }
+  if (type === 'loading') {
+    return <span>Loading...</span>
+  }
 
-    if (type === 'error' || typeof data === 'undefined' && typeof actions === 'undefined') {
-        return <span>Error</span>
-    }
+  if (
+    type === 'error' ||
+    (typeof data === 'undefined' && typeof actions === 'undefined')
+  ) {
+    return <span>Error</span>
+  }
 
-    return (
-        <div className="field-plugin">
-            <ModalToggle isModalOpen={data.isModalOpen} setModalOpen={actions.setModalOpen}/>
-            <Counter setValue={actions.setValue} value={data.value}/>
-            <AssetSelector selectAsset={actions.selectAsset}/>
-        </div>
-    )
+  return (
+    <div className="field-plugin">
+      <ModalToggle
+        isModalOpen={data.isModalOpen}
+        setModalOpen={actions.setModalOpen}
+      />
+      <Counter
+        setValue={actions.setValue}
+        value={data.value}
+      />
+      <AssetSelector selectAsset={actions.selectAsset} />
+    </div>
+  )
 }
 
 export default App

--- a/packages/cli/templates/react/src/components/AssetSelector.tsx
+++ b/packages/cli/templates/react/src/components/AssetSelector.tsx
@@ -1,23 +1,23 @@
-import {FunctionComponent, useState} from 'react'
-import {SelectAsset} from "@storyblok/field-plugin";
-import Button from "./button/Button";
+import { FunctionComponent, useState } from 'react'
+import { SelectAsset } from '@storyblok/field-plugin'
+import Button from './button/Button'
 
 type AssetSelectorFunc = FunctionComponent<{
-    selectAsset: SelectAsset
+  selectAsset: SelectAsset
 }>
-const AssetSelector: AssetSelectorFunc = ({selectAsset}) => {
-    const [imageUrl, setImageUrl] = useState<string>('')
+const AssetSelector: AssetSelectorFunc = ({ selectAsset }) => {
+  const [imageUrl, setImageUrl] = useState<string>('')
 
-    const handleSelectAsset = async () => {
-        setImageUrl(await selectAsset())
-    }
+  const handleSelectAsset = async () => {
+    setImageUrl(await selectAsset())
+  }
 
-    return (
-        <div className="asset-selector">
-            <Button onClick={handleSelectAsset}>Select Asset</Button>
-            <span>Image Url: {imageUrl}</span>
-        </div>
-    )
+  return (
+    <div className="asset-selector">
+      <Button onClick={handleSelectAsset}>Select Asset</Button>
+      <span>Image Url: {imageUrl}</span>
+    </div>
+  )
 }
 
 export default AssetSelector

--- a/packages/cli/templates/react/src/components/Counter.tsx
+++ b/packages/cli/templates/react/src/components/Counter.tsx
@@ -1,23 +1,22 @@
-import {FunctionComponent} from "react";
-import {SetValue} from "@storyblok/field-plugin";
-import Button from "./button/Button";
+import { FunctionComponent } from 'react'
+import { SetValue } from '@storyblok/field-plugin'
+import Button from './button/Button'
 
 type CounterFunc = FunctionComponent<{
-    setValue: SetValue,
-    value: unknown
+  setValue: SetValue
+  value: unknown
 }>
-const Counter: CounterFunc = ({setValue, value}) => {
+const Counter: CounterFunc = ({ setValue, value }) => {
+  const label = typeof value !== 'number' ? 0 : JSON.stringify(value)
+  const handleIncrement = () => {
+    setValue((typeof value === 'number' ? value : 0) + 1)
+  }
 
-    const label = typeof value !== 'number' ? 0 : JSON.stringify(value)
-    const handleIncrement = () => {
-        setValue((typeof value === 'number' ? value : 0) + 1)
-    }
-
-    return (
-        <div className="increment">
-            <Button onClick={handleIncrement}>Increment {label}</Button>
-        </div>
-    )
+  return (
+    <div className="increment">
+      <Button onClick={handleIncrement}>Increment {label}</Button>
+    </div>
+  )
 }
 
 export default Counter

--- a/packages/cli/templates/react/src/components/ModalToggle.tsx
+++ b/packages/cli/templates/react/src/components/ModalToggle.tsx
@@ -1,22 +1,22 @@
-import {FunctionComponent} from "react";
-import {SetModalOpen} from "@storyblok/field-plugin";
-import Button from "./button/Button";
+import { FunctionComponent } from 'react'
+import { SetModalOpen } from '@storyblok/field-plugin'
+import Button from './button/Button'
 
 type ModalToggleFunc = FunctionComponent<{
-    setModalOpen: SetModalOpen,
-    isModalOpen: boolean
+  setModalOpen: SetModalOpen
+  isModalOpen: boolean
 }>
-const ModalToggle: ModalToggleFunc = ({setModalOpen, isModalOpen}) => {
-    const handleToggleModal = (isOpen: boolean) => {
-        setModalOpen(isOpen)
-    }
-    return (
-        <div className="modal-toggle">
-            <Button onClick={() => handleToggleModal(!isModalOpen)}>
-                {isModalOpen ? 'Close' : 'Open'} Modal
-            </Button>
-        </div>
-    )
+const ModalToggle: ModalToggleFunc = ({ setModalOpen, isModalOpen }) => {
+  const handleToggleModal = (isOpen: boolean) => {
+    setModalOpen(isOpen)
+  }
+  return (
+    <div className="modal-toggle">
+      <Button onClick={() => handleToggleModal(!isModalOpen)}>
+        {isModalOpen ? 'Close' : 'Open'} Modal
+      </Button>
+    </div>
+  )
 }
 
 export default ModalToggle

--- a/packages/cli/templates/react/src/components/button/Button.tsx
+++ b/packages/cli/templates/react/src/components/button/Button.tsx
@@ -1,11 +1,13 @@
 import './button.css'
-import {FunctionComponent, ReactNode} from "react";
+import { FunctionComponent, ReactNode } from 'react'
 
 type ButtonFunc = FunctionComponent<{
-    children: ReactNode,
-    onClick: () => void
+  children: ReactNode
+  onClick: () => void
 }>
 
-const Button: ButtonFunc = ({children, onClick}) => (<button onClick={onClick}>{children}</button>)
+const Button: ButtonFunc = ({ children, onClick }) => (
+  <button onClick={onClick}>{children}</button>
+)
 
-export default Button;
+export default Button

--- a/packages/cli/templates/react/src/components/button/button.css
+++ b/packages/cli/templates/react/src/components/button/button.css
@@ -1,27 +1,26 @@
 button {
-    font-family: inherit;
-    font-size: inherit;
-    font-weight: 500;
-    line-height: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 500;
+  line-height: inherit;
 
-    width: 100%;
-    background-color: var(--sb_green);
-    color: var(--white);
+  width: 100%;
+  background-color: var(--sb_green);
+  color: var(--white);
 
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 
-    cursor: pointer;
-    transition: all .1s ease-in-out;
+  cursor: pointer;
+  transition: all 0.1s ease-in-out;
 
-    padding: 9px 21px;
-    border-radius: 5px;
-    border: 1px solid transparent;
+  padding: 9px 21px;
+  border-radius: 5px;
+  border: 1px solid transparent;
 }
 
 button:hover {
-    background-color: var(--sb_green_75);
+  background-color: var(--sb_green_75);
 }
-

--- a/packages/cli/templates/react/src/index.css
+++ b/packages/cli/templates/react/src/index.css
@@ -1,81 +1,80 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
 
 :root {
-    /*Storyblok colors*/
-    --sb_green: #00b3b0;
-    --sb_green_75: #40c6c4;
-    --sb_green_50: #7fd9d7;
-    --sb_green_25: #d9f4f3;
-    --sb_dark_blue: #1b243f;
-    --sb_dark_blue_75: #545b6f;
-    --sb_dark_blue_50: #8d919f;
-    --sb_dark_blue_25: #c6c8cf;
-    --green: #2db47d;
-    --green_75: #62c79e;
-    --green_50: #96d9be;
-    --green_25: #caecde;
-    --green_disabled: #004e4c;
-    --yellow: #fbce41;
-    --yellow_75: #fcdb71;
-    --yellow_50: #fde6a0;
-    --yellow_25: #fef3cf;
-    --blue: #395ece;
-    --blue_75: #6b87db;
-    --blue_50: #9caee6;
-    --blue_25: #cdd7f3;
-    --orange: #ffac00;
-    --orange_75: #ffc140;
-    --orange_50: #ffd57f;
-    --orange_25: #ffeabf;
-    --red: #ff6159;
-    --red_75: #ff8983;
-    --red_50: #ffb0ac;
-    --red_25: #ffd7d5;
-    --light: #dfe3e8;
-    --light_75: #e7eaee;
-    --light_50: #eff1f3;
-    --light_25: #f7f8f9;
-    --light_gray: #b1b5be;
-    --black: #101525;
-    --white: #fff;
+  /*Storyblok colors*/
+  --sb_green: #00b3b0;
+  --sb_green_75: #40c6c4;
+  --sb_green_50: #7fd9d7;
+  --sb_green_25: #d9f4f3;
+  --sb_dark_blue: #1b243f;
+  --sb_dark_blue_75: #545b6f;
+  --sb_dark_blue_50: #8d919f;
+  --sb_dark_blue_25: #c6c8cf;
+  --green: #2db47d;
+  --green_75: #62c79e;
+  --green_50: #96d9be;
+  --green_25: #caecde;
+  --green_disabled: #004e4c;
+  --yellow: #fbce41;
+  --yellow_75: #fcdb71;
+  --yellow_50: #fde6a0;
+  --yellow_25: #fef3cf;
+  --blue: #395ece;
+  --blue_75: #6b87db;
+  --blue_50: #9caee6;
+  --blue_25: #cdd7f3;
+  --orange: #ffac00;
+  --orange_75: #ffc140;
+  --orange_50: #ffd57f;
+  --orange_25: #ffeabf;
+  --red: #ff6159;
+  --red_75: #ff8983;
+  --red_50: #ffb0ac;
+  --red_25: #ffd7d5;
+  --light: #dfe3e8;
+  --light_75: #e7eaee;
+  --light_50: #eff1f3;
+  --light_25: #f7f8f9;
+  --light_gray: #b1b5be;
+  --black: #101525;
+  --white: #fff;
 
-
-    font-family: 'Roboto', sans-serif;
-    font-style: normal;
-    line-height: 1.5;
-    font-weight: 400;
-    font-size: 1rem;
-    font-synthesis: none;
-    text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-text-size-adjust: 100%;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 1rem;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
 }
 
 #app {
-    width: 100%;
+  width: 100%;
 }
 
 /*Element Styles*/
 body {
-    margin: 0;
-    display: flex;
-    box-sizing:border-box;
+  margin: 0;
+  display: flex;
+  box-sizing: border-box;
 }
-
 
 /*Layout Styles*/
 
 .field-plugin {
-    display: flex;
-    gap: 10px;
-    flex-direction: column;
+  display: flex;
+  gap: 10px;
+  flex-direction: column;
 }
 
-
-.increment, .asset-selector, .modal-toggle {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    align-items: center;
+.increment,
+.asset-selector,
+.modal-toggle {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  align-items: center;
 }

--- a/packages/cli/templates/react/src/main.tsx
+++ b/packages/cli/templates/react/src/main.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './index.css'
-import {createRootElement} from "./createRootElement";
+import { createRootElement } from './createRootElement'
 
 const rootNode = createRootElement()
 document.body.appendChild(rootNode)

--- a/packages/cli/templates/react/src/useFieldPlugin.ts
+++ b/packages/cli/templates/react/src/useFieldPlugin.ts
@@ -1,19 +1,16 @@
-import {
-    createFieldPlugin,
-    FieldPluginResponse,
-} from "@storyblok/field-plugin";
-import {useEffect, useState} from "react";
+import { createFieldPlugin, FieldPluginResponse } from '@storyblok/field-plugin'
+import { useEffect, useState } from 'react'
 
-type UseFieldPlugin = () => FieldPluginResponse;
+type UseFieldPlugin = () => FieldPluginResponse
 
 export const useFieldPlugin: UseFieldPlugin = () => {
-    const [state, setState] = useState<FieldPluginResponse>({
-        type: "loading",
-    });
+  const [state, setState] = useState<FieldPluginResponse>({
+    type: 'loading',
+  })
 
-    useEffect(() => {
-        return createFieldPlugin(setState);
-    }, []);
+  useEffect(() => {
+    return createFieldPlugin(setState)
+  }, [])
 
-    return state;
-};
+  return state
+}

--- a/packages/cli/templates/react/tsconfig.json
+++ b/packages/cli/templates/react/tsconfig.json
@@ -2,11 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ESNext"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": false,
@@ -20,9 +16,7 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "references": [
     {
       "path": "./tsconfig.node.json"

--- a/packages/cli/templates/react/tsconfig.node.json
+++ b/packages/cli/templates/react/tsconfig.node.json
@@ -5,7 +5,5 @@
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true
   },
-  "include": [
-    "vite.config.ts"
-  ]
+  "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## What?

Formatted the react starter with

```shell
yarn run prettier --write packages/cli/templates/react
```

Nothing else.

Using our rules in the root of the monorepo. Prettier is still absetn from the react template `package.json`.

## Why?

For future adjustments, there will be fewer lines changes.

## How to test? (optional)
