### PR TITLE
EXT-1305: Add repository to package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,6 +9,11 @@
     "bin.js",
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storyblok/field-plugin.git",
+    "directory": "packages/field-plugin-cli"
+  },
   "scripts": {
     "prepare": "yarn build",
     "create": "vite build:quiet && node bin.js",

--- a/packages/field-plugin/package.json
+++ b/packages/field-plugin/package.json
@@ -6,11 +6,6 @@
   "files": [
     "dist"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/storyblok/field-plugin.git",
-    "directory": "packages/field-plugin"
-  },
   "type": "module",
   "module": "./dist/field-plugin.js",
   "main": "./dist/field-plugin.umd.cjs",
@@ -20,6 +15,11 @@
       "import": "./dist/field-plugin.js",
       "require": "./dist/field-plugin.umd.cjs"
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storyblok/field-plugin.git",
+    "directory": "packages/field-plugin"
   },
   "scripts": {
     "check:types": "tsc --noEmit",

--- a/packages/field-plugin/package.json
+++ b/packages/field-plugin/package.json
@@ -6,6 +6,11 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storyblok/field-plugin.git",
+    "directory": "packages/field-plugin"
+  },
   "type": "module",
   "module": "./dist/field-plugin.js",
   "main": "./dist/field-plugin.umd.cjs",


### PR DESCRIPTION
## What?

For both NPM packages, adding `repository` property to the `package.json` files.

docs: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository

We can think of setting the `homepage` property once we have some proper documentation on storyblok.com.

## Why?

So that the repository is listed on NPM.

