### PR TITLE
EXT-1331: CLI create and deploy

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "prepare": "yarn build",
-    "create": "yarn build && node bin.js",
+    "create": "yarn build && node bin.js create",
     "deploy": "yarn build && node bin.js deploy",
     "build": "vite build && cp -r templates dist/",
     "build:quiet": "vite build --logLevel error",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,8 +16,8 @@
   },
   "scripts": {
     "prepare": "yarn build",
-    "create": "vite build:quiet && node bin.js",
-    "deploy": "vite build:quiet && node bin.js deploy",
+    "create": "yarn build && node bin.js",
+    "deploy": "yarn build && node bin.js deploy",
     "build": "vite build && cp -r templates dist/",
     "build:quiet": "vite build --logLevel error",
     "test": "vitest run",


### PR DESCRIPTION
## What?

Fixing the CLI's `create` and `deploy` scripts in `package.json`.

## Why?

Running `yarn create` and `yarn deploy` would fail. 

## How to test? (optional)

Run

```shell
yarn workspace @storyblok/field-plugin-cli run create
yarn workspace @storyblok/field-plugin-cli run deploy
```