### PR TITLE
EXT-1356: fix deploy command in js, vue3, react template

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -178,6 +178,7 @@ Please see our [contributing guidelines](https://github.com/storyblok/.github/bl
 When adding a new template to this repository, think of the following:
 
 - `.gitignore` files must be named `gitignore`. Otherwise, NPM will exclude the file from the release. The `@storyblok/field-plugin-cli` will automatically rename the file to `.gitignore`.  
+- Add `"deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"` to the `package.json`
 
 ## :1st_place_medal: Credits
 Special thanks goes to all the people that contribute to this library!

--- a/packages/cli/templates/js/package.json
+++ b/packages/cli/templates/js/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "check:types": "tsc --noEmit"
+    "check:types": "tsc --noEmit",
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "0.0.1-alpha.2"

--- a/packages/cli/templates/react/package.json
+++ b/packages/cli/templates/react/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "0.0.1-alpha.2",

--- a/packages/cli/templates/vue3/package.json
+++ b/packages/cli/templates/vue3/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "0.0.1-alpha.2",


### PR DESCRIPTION
## What?

This fixes the deploy command in js, vue3, react template inside monorepo (Basically it was correct only for the vue 2 template)

Before this PR, `package.json` of those templates had the following script:

```
"scripts": {
  ...
  "deploy": "undefined --dotEnvPath '../../.env'"
}
```

## Why?

When using the boilerplate, `add` command appends `--dotEnvPath` parameter, so that the deploy command can read the .env file from the root of the monorepo.

```
        packageJson['scripts']['deploy'] += " --dotEnvPath '../../.env'"
```

Since js, vue3, react templates didn't even have `deploy` script in their package.json, we got `undefined --dotEnvPath '../../.env'`.

https://github.com/storyblok/field-plugin/blob/9f1b8a8c6a01cf58857325ec2b699ab2f92d0b36/packages/cli/src/commands/add.ts#L102:L102