### PR TITLE
EXT-1299: pass name option to deploy command

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -2,12 +2,7 @@ import { existsSync, readFileSync, lstatSync } from 'fs'
 import { bold, cyan, red, yellow, green } from 'kleur/colors'
 import { basename, resolve } from 'path'
 import prompts from 'prompts'
-import {
-  getPersonalAccessToken,
-  loadEnvironmentVariables,
-  promptName,
-  validateToken,
-} from '../utils'
+import { getPersonalAccessToken, promptName } from '../utils'
 import { StoryblokClient } from '../storyblok/storyblok-client'
 
 const packageNameMessage =
@@ -18,10 +13,10 @@ export type FieldType = { id: number; name: string; body: string }
 export type DeployArgs = {
   skipPrompts: boolean
   dir: string
-  name?: string
-  token?: string
-  output?: string
-  dotEnvPath?: string
+  name: undefined | string
+  token: undefined | string
+  output: undefined | string
+  dotEnvPath: undefined | string
 }
 
 type DeployFunc = (args: DeployArgs) => Promise<void>

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -72,12 +72,13 @@ export const main = () => {
       ),
     )
     .action(async function (this: Command) {
-      const { dir, skipPrompts, token, output, dotEnvPath } =
+      const { dir, skipPrompts, name, token, output, dotEnvPath } =
         this.opts<DeployArgs>()
 
       await deploy({
         skipPrompts,
         token,
+        name,
         dir,
         output,
         dotEnvPath,


### PR DESCRIPTION
## What?

This PR passes `name` option to the `deploy` command correctly.

This was missing before.
