### PR TITLE
EXT-1290: Container Modal Height

### DIFF
--- a/packages/container/src/components/FieldTypePreview.tsx
+++ b/packages/container/src/components/FieldTypePreview.tsx
@@ -63,7 +63,7 @@ const FieldTypeContainer: FunctionComponent<
             bgcolor: 'background.paper',
             p: 6,
             borderRadius: 1,
-            maxHeight: '80%',
+            height: '80%',
             overflowY: 'scroll',
           }
         : {

--- a/packages/container/src/components/FieldTypePreview.tsx
+++ b/packages/container/src/components/FieldTypePreview.tsx
@@ -64,7 +64,7 @@ const FieldTypeContainer: FunctionComponent<
             p: 6,
             borderRadius: 1,
             height: '80%',
-            overflowY: 'scroll',
+            overflowY: 'auto',
           }
         : {
             overflow: 'auto',


### PR DESCRIPTION
## What?

- Sets the modal height to 80% of the height. 
- Sets the scroll to auto, so that the scroll only appear when the content overflows.

## Why?

Previously, the modal didn't have a fixed height. If the field plugin wasn't tall, the modal dialog wouldn't cover much of the screen.

## How to test? (optional)

Open a field plugin in modal mode and remove most, if not all, elements. With the browser dev tools, set the iframe height to 100px. The window should still cover the 80% of the height.