### PR TITLE
EXT-1290: Remove Iframe Component

### DIFF
--- a/packages/container/src/components/FieldTypePreview.tsx
+++ b/packages/container/src/components/FieldTypePreview.tsx
@@ -82,6 +82,7 @@ export const FieldTypePreview = forwardRef<
             ref={ref}
             key={props.uid}
             component="iframe"
+            title="Field Plugin Preview"
             style={{
               height: props.height,
               width: '100%',

--- a/packages/container/src/components/FieldTypePreview.tsx
+++ b/packages/container/src/components/FieldTypePreview.tsx
@@ -1,29 +1,6 @@
 import { forwardRef, FunctionComponent, PropsWithChildren } from 'react'
 import { Backdrop, Box } from '@mui/material'
 
-const Iframe = forwardRef<
-  HTMLIFrameElement,
-  {
-    src: string
-    height: string
-    isModal: boolean
-  }
->(function Iframe(props, ref) {
-  return (
-    <Box
-      component="iframe"
-      ref={ref}
-      style={{
-        height: props.height,
-        width: '100%',
-        flex: 1,
-        border: 'none',
-      }}
-      src={props.src}
-    />
-  )
-})
-
 const FieldTypeModal: FunctionComponent<
   PropsWithChildren<{
     isModal: boolean
@@ -101,10 +78,17 @@ export const FieldTypePreview = forwardRef<
       />
       <FieldTypeModal isModal={props.isModal}>
         <FieldTypeContainer isModal={props.isModal}>
-          <Iframe
-            {...props}
+          <Box
             ref={ref}
             key={props.uid}
+            component="iframe"
+            style={{
+              height: props.height,
+              width: '100%',
+              flex: 1,
+              border: 'none',
+            }}
+            {...props}
           />
         </FieldTypeContainer>
       </FieldTypeModal>


### PR DESCRIPTION
## What?

Removing the Iframe component.

## Why?

The `Iframe` componen wraps a single box element with `component` set to `"iframe"`. It's simpler to just render the iframe directy in `FieldTypePreview`

