### PR TITLE
EXT-1307: Build Commands that Refer to the Field Plugin Editor and CLI

### DIFF
--- a/packages/cli/templates/react/print-plugin.ts
+++ b/packages/cli/templates/react/print-plugin.ts
@@ -1,0 +1,25 @@
+import { PluginOption } from 'vite'
+
+const printPlugin = (): PluginOption => ({
+  name: 'storyblok-field-plugin',
+  writeBundle: () => {
+    console.log(`
+    To deploy to Storyblok, run
+    
+      > yarn deploy
+    `)
+  },
+  buildStart: () => {
+    console.log(`
+    Partner Portal plugins:
+      - https://app.storyblok.com/#/partner/fields
+    Personal plugins:
+      - https://app.storyblok.com/#/me/plugins
+    
+    Try out the app with the Field Plugin Sandbox:
+      - https://storyblok-field-plugin-sandbox.vercel.app
+    `)
+  },
+})
+
+export default printPlugin

--- a/packages/cli/templates/react/tsconfig.node.json
+++ b/packages/cli/templates/react/tsconfig.node.json
@@ -5,5 +5,5 @@
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "print-plugin.ts"]
 }

--- a/packages/cli/templates/react/vite.config.ts
+++ b/packages/cli/templates/react/vite.config.ts
@@ -1,10 +1,11 @@
-import { defineConfig, PluginOption } from 'vite'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import cssInjectedByJs from 'vite-plugin-css-injected-by-js'
+import printPlugin from './print-plugin'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), cssInjectedByJsPlugin()],
+  plugins: [react(), cssInjectedByJs(), printPlugin()],
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
## What?

When running the `build` and `dev` scripts from `package.json` from a field plugin, Vite will print out a message for the developer with insteruction on where to find a) the field plugin editors, and b) the container. This is done via very simple vite plugin.

Futhermore, when running `build`, the developer will see a suggestion to run the CLI's `deploy` command.

## Why?

At the end of `dev`, vite will by default only print the url for opening the hosted app itself. But since field plugins can only be previewed in a container, the link that they're really interested in is the one to the deployed container.

Furthermore, it is not so obvious to users how field plugins can be deployed. By printing out a suggestion to run the CLI's `deploy` command, the user is guided throughout from the initial creation of the field plugin to successfull deployment. (The `deploy` command will contain a reference to the page where personal access tokens can be generated).

## How to test? (optional)

Run

```shell
yarn build
yarn dev
```

Two messages will be printed out.

For dev