### PR TITLE
EXT-1388: Disabling ESLint rule react/prop-type

### DIFF
--- a/packages/cli/templates/react/.eslintrc.cjs
+++ b/packages/cli/templates/react/.eslintrc.cjs
@@ -28,5 +28,7 @@ module.exports = {
     project: ['./tsconfig.json', './tsconfig.node.json'],
   },
   plugins: ['react', '@typescript-eslint'],
-  rules: {},
+  rules: {
+    'react/prop-types': 'off',
+  }
 }


### PR DESCRIPTION
## What?

Disabling ESLint rule react/prop-type in the React template.

## Why?

React propTypes are nowadays not part of the core React library. Prop types is runtime checking and not needed together with TypeScript. 
