### PR TITLE
EXT-1300: respect skipPrompts when deciding package name at deploy command

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -67,10 +67,10 @@ export const deploy: DeployFunc = async ({
     process.exit(1)
   }
 
+  console.log(bold(cyan(`[info] Plugin name: \`${packageName}\``)))
+
   // path of the specific field-plugin package
-
   const defaultOutputPath = resolve(dir, 'dist', 'index.js')
-
   const outputPath =
     typeof output !== 'undefined' ? resolve(output) : defaultOutputPath
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -57,13 +57,7 @@ export const deploy: DeployFunc = async ({
     process.exit(1)
   }
 
-  const packageName =
-    typeof name === 'string' && name.length > 0
-      ? name
-      : await promptName({
-          message: packageNameMessage,
-          initialValue: getPackageName(dir),
-        })
+  const packageName = await decidePackageName({ name, skipPrompts, dir })
 
   if (typeof packageName !== 'string' || packageName === '') {
     console.log(red('[ERROR]'), 'Package name is missing.')
@@ -109,6 +103,29 @@ export const deploy: DeployFunc = async ({
   console.log(
     'You can also find it in "My account > My Plugins" at the bottom of the sidebar.',
   )
+}
+
+const decidePackageName = async ({
+  name,
+  skipPrompts,
+  dir,
+}: {
+  name?: string
+  skipPrompts: boolean
+  dir: string
+}) => {
+  if (typeof name === 'string' && name.length > 0) {
+    return name
+  }
+
+  if (skipPrompts) {
+    return getPackageName(dir)
+  }
+
+  return await promptName({
+    message: packageNameMessage,
+    initialValue: getPackageName(dir),
+  })
 }
 
 const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {

--- a/packages/cli/src/storyblok/storyblok-client.ts
+++ b/packages/cli/src/storyblok/storyblok-client.ts
@@ -76,8 +76,8 @@ export const StoryblokClient: StoryblokClientFunc = (token) => {
         field_type,
       }),
     })
-    const json = (await response.json()) as FieldPluginResponse
-    handleErrorIfExists(response, json)
+    // The Update API returns an empty string as response body
+    handleErrorIfExists(response, {})
   }
 
   const createFieldType: CreateFieldTypeFunc = async (body) => {


### PR DESCRIPTION
## What?

This PR fixes the bug that didn't respect `skipPrompts` option at the `deploy` command, and asked for package name.

This PR also fixes a regression that the Update API method threw an error due to a wrong error handling (this part was not deployed yet).

## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->