### PR TITLE
EXT-1314: rename `new` script to `add-plugin` in monorepo template

### DIFF
--- a/packages/cli/templates/monorepo/package.json
+++ b/packages/cli/templates/monorepo/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "new": "npx @storyblok/field-plugin-cli@alpha add --dir \"./packages\" --structure monorepo",
+    "add-plugin": "npx @storyblok/field-plugin-cli@alpha add --dir \"./packages\" --structure monorepo",
     "lint": "eslint --ext .js,.vue .",
     "format": "prettier . --write"
   },


### PR DESCRIPTION
## What?

`add-plugin` is more descriptive than `new`.