### PR TITLE
EXT-1087: support different endpoints

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -10,7 +10,12 @@ import {
 } from 'fs'
 import walk from 'walkdir'
 import { MONOREPO_TEMPLATE_PATH, TEMPLATES, TEMPLATES_PATH } from '../../config'
-import { filterPathsToInclude, promptName, runCommand } from '../utils'
+import {
+  betterPrompts,
+  filterPathsToInclude,
+  promptName,
+  runCommand,
+} from '../utils'
 
 export type Template = 'vue2'
 
@@ -33,21 +38,14 @@ export type PackageJson = {
 export type AddFunc = (args: AddArgs) => Promise<{ destPath: string }>
 
 const selectTemplate = async () => {
-  const { template } = (await prompts(
-    [
-      {
-        type: 'select',
-        name: 'template',
-        message: 'Which template?',
-        choices: TEMPLATES,
-      },
-    ],
+  const { template } = await betterPrompts<{ template: string }>([
     {
-      onCancel: () => {
-        process.exit(1)
-      },
+      type: 'select',
+      name: 'template',
+      message: 'Which template?',
+      choices: TEMPLATES,
     },
-  )) as { template: string }
+  ])
   return template
 }
 

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -2,6 +2,7 @@ import prompts from 'prompts'
 import { createMonorepo, type CreateMonorepoArgs } from './monorepo'
 import { createPolyrepo, type CreatePolyrepoArgs } from './polyrepo'
 import { Structure } from '../add'
+import { betterPrompts } from '../../utils'
 
 export type CreateArgs =
   | ({
@@ -14,33 +15,26 @@ export type CreateArgs =
 export type CreateFunc = (args: CreateArgs) => Promise<void>
 
 const selectRepositoryStructure = async () => {
-  const { structure } = (await prompts(
-    [
-      {
-        type: 'select',
-        name: 'structure',
-        message:
-          'How many field plugins potentially do you want in this repository?',
-        choices: [
-          {
-            title: 'Monorepo (multiple plugins in one repo)',
-            // description: 'some description if exists',
-            value: 'monorepo',
-          },
-          {
-            title: 'Polyrepo (one plugin in one repo)',
-            // description: 'some description if exists',
-            value: 'polyrepo',
-          },
-        ],
-      },
-    ],
+  const { structure } = await betterPrompts<{ structure: Structure }>([
     {
-      onCancel: () => {
-        process.exit(1)
-      },
+      type: 'select',
+      name: 'structure',
+      message:
+        'How many field plugins potentially do you want in this repository?',
+      choices: [
+        {
+          title: 'Monorepo (multiple plugins in one repo)',
+          // description: 'some description if exists',
+          value: 'monorepo',
+        },
+        {
+          title: 'Polyrepo (one plugin in one repo)',
+          // description: 'some description if exists',
+          value: 'polyrepo',
+        },
+      ],
     },
-  )) as { structure: Structure }
+  ])
   return structure
 }
 

--- a/packages/cli/src/commands/create/monorepo.ts
+++ b/packages/cli/src/commands/create/monorepo.ts
@@ -4,6 +4,7 @@ import { bold, cyan } from 'kleur/colors'
 import { dirname, resolve } from 'path'
 import { MONOREPO_TEMPLATE_PATH, TEMPLATES_PATH } from '../../../config'
 import {
+  betterPrompts,
   filterPathsToInclude,
   initializeNewRepo,
   runCommand,
@@ -35,22 +36,15 @@ const isValidRepoName = ({
 }
 
 const promptRepoName = async (dir: string) => {
-  const { name } = (await prompts(
-    [
-      {
-        type: 'text',
-        name: 'name',
-        message:
-          'What is your repository name?\n  (Lowercase alphanumeric and dash are allowed.)',
-        validate: (name: string) => isValidRepoName({ dir, name }),
-      },
-    ],
+  const { name } = await betterPrompts<{ name: string }>([
     {
-      onCancel: () => {
-        process.exit(1)
-      },
+      type: 'text',
+      name: 'name',
+      message:
+        'What is your repository name?\n  (Lowercase alphanumeric and dash are allowed.)',
+      validate: (name: string) => isValidRepoName({ dir, name }),
     },
-  )) as { name: string }
+  ])
   return name
 }
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -283,7 +283,7 @@ const isBuildable = (path: string) => {
 }
 
 const selectApiScope = async (token: string): Promise<Scope> => {
-  const accessibleToMySpace = await StoryblokClient({
+  const accessibleToMyPlugins = await StoryblokClient({
     token,
     scope: 'my-plugins',
   }).isAuthenticated()
@@ -293,7 +293,7 @@ const selectApiScope = async (token: string): Promise<Scope> => {
     scope: 'partner-portal',
   }).isAuthenticated()
 
-  if (!accessibleToMySpace && !accessibleToPartnerPortal) {
+  if (!accessibleToMyPlugins && !accessibleToPartnerPortal) {
     console.error(
       red('[ERROR]'),
       `The token appears to be invalid as it does not have access to either My Plugins or the plugins on the Partner Portal.`,
@@ -307,7 +307,7 @@ const selectApiScope = async (token: string): Promise<Scope> => {
       name: 'scope',
       message: 'Where to deploy the plugin?',
       choices: [
-        accessibleToMySpace && {
+        accessibleToMyPlugins && {
           title: 'My Plugins',
           value: 'my-plugins',
         },

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -285,7 +285,7 @@ const isBuildable = (path: string) => {
 const selectApiScope = async (token: string): Promise<Scope> => {
   const accessibleToMySpace = await StoryblokClient({
     token,
-    scope: 'my-space',
+    scope: 'my-plugins',
   }).isAuthenticated()
 
   const accessibleToPartnerPortal = await StoryblokClient({
@@ -308,8 +308,8 @@ const selectApiScope = async (token: string): Promise<Scope> => {
       message: 'Where to deploy the plugin?',
       choices: [
         accessibleToMySpace && {
-          title: 'My Space',
-          value: 'my-space',
+          title: 'My Plugins',
+          value: 'my-plugins',
         },
         accessibleToPartnerPortal && {
           title: 'Partner Portal',

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -57,13 +57,7 @@ export const deploy: DeployFunc = async ({
     process.exit(1)
   }
 
-  const packageName =
-    typeof name === 'string' && name.length > 0
-      ? name
-      : await promptName({
-          message: packageNameMessage,
-          initialValue: getPackageName(dir),
-        })
+  const packageName = await decidePackageName({ name, skipPrompts, dir })
 
   if (typeof packageName !== 'string' || packageName === '') {
     console.log(red('[ERROR]'), 'Package name is missing.')
@@ -73,10 +67,10 @@ export const deploy: DeployFunc = async ({
     process.exit(1)
   }
 
+  console.log(bold(cyan(`[info] Plugin name: \`${packageName}\``)))
+
   // path of the specific field-plugin package
-
   const defaultOutputPath = resolve(dir, 'dist', 'index.js')
-
   const outputPath =
     typeof output !== 'undefined' ? resolve(output) : defaultOutputPath
 
@@ -109,6 +103,29 @@ export const deploy: DeployFunc = async ({
   console.log(
     'You can also find it in "My account > My Plugins" at the bottom of the sidebar.',
   )
+}
+
+const decidePackageName = async ({
+  name,
+  skipPrompts,
+  dir,
+}: {
+  name?: string
+  skipPrompts: boolean
+  dir: string
+}) => {
+  if (typeof name === 'string' && name.length > 0) {
+    return name
+  }
+
+  if (skipPrompts) {
+    return getPackageName(dir)
+  }
+
+  return await promptName({
+    message: packageNameMessage,
+    initialValue: getPackageName(dir),
+  })
 }
 
 const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -71,8 +71,14 @@ export const main = () => {
         'path to the `.env` file which stores the environment variable `STORYBLOK_PERSONAL_ACCESS_TOKEN`',
       ),
     )
+    .addOption(
+      new Option(
+        '--scope <value>',
+        `where to deploy the field plugin ('my-space' | 'partner-portal')`,
+      ),
+    )
     .action(async function (this: Command) {
-      const { dir, skipPrompts, name, token, output, dotEnvPath } =
+      const { dir, skipPrompts, name, token, output, dotEnvPath, scope } =
         this.opts<DeployArgs>()
 
       await deploy({
@@ -82,6 +88,7 @@ export const main = () => {
         dir,
         output,
         dotEnvPath,
+        scope,
       })
     })
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -74,7 +74,7 @@ export const main = () => {
     .addOption(
       new Option(
         '--scope <value>',
-        `where to deploy the field plugin ('my-space' | 'partner-portal')`,
+        `where to deploy the field plugin ('my-plugins' | 'partner-portal')`,
       ),
     )
     .action(async function (this: Command) {

--- a/packages/cli/src/storyblok/storyblok-client.ts
+++ b/packages/cli/src/storyblok/storyblok-client.ts
@@ -1,10 +1,11 @@
 import { red } from 'kleur/colors'
 import type { Response } from 'node-fetch'
 
-const PARTNER_FIELD_TYPES_API_ENDPOINT =
-  'https://mapi.storyblok.com/v1/partner_field_types/'
-
 export type FieldType = { id: number; name: string; body: string }
+
+export type Scope = 'my-space' | 'partner-portal'
+
+type IsAuthenticatedFunc = () => Promise<boolean>
 
 type CreateFieldTypeFunc = (body: {
   name: string
@@ -16,34 +17,46 @@ type UpdateFieldTypeFunc = (args: {
   field_type: Partial<FieldType>
 }) => Promise<void>
 
-type FetchAllFieldTypesFunc = (page?: number) => Promise<FieldType[]>
+type FetchFieldTypesFunc = (page?: number) => Promise<FieldType[]>
 
 type FieldPluginResponse = {
   error?: string
   field_type: FieldType
 }
 
-type StoryblokClientFunc = (token: string) => {
-  fetchAllFieldTypes: FetchAllFieldTypesFunc
+type StoryblokClientFunc = (params: { token: string; scope: Scope }) => {
+  isAuthenticated: IsAuthenticatedFunc
+  fetchAllFieldTypes: FetchFieldTypesFunc
   createFieldType: CreateFieldTypeFunc
   updateFieldType: UpdateFieldTypeFunc
 }
 
-export const StoryblokClient: StoryblokClientFunc = (token) => {
+export const StoryblokClient: StoryblokClientFunc = ({ token, scope }) => {
+  const FIELD_TYPES_API_ENDPOINT =
+    scope === 'partner-portal'
+      ? 'https://mapi.storyblok.com/v1/partner_field_types/'
+      : 'https://mapi.storyblok.com/v1/field_types/'
+
   const headers = {
     Authorization: token ?? '',
     'Content-Type': 'application/json',
   }
 
-  const fetchFieldTypes: FetchAllFieldTypesFunc = async (page = 1) => {
+  const isAuthenticated: IsAuthenticatedFunc = async () => {
     const fetch = (await import('node-fetch')).default
-    const response = await fetch(
-      `${PARTNER_FIELD_TYPES_API_ENDPOINT}?page=${page}`,
-      {
-        method: 'GET',
-        headers,
-      },
-    )
+    const response = await fetch(`${FIELD_TYPES_API_ENDPOINT}`, {
+      method: 'GET',
+      headers,
+    })
+    return response.ok
+  }
+
+  const fetchFieldTypes: FetchFieldTypesFunc = async (page = 1) => {
+    const fetch = (await import('node-fetch')).default
+    const response = await fetch(`${FIELD_TYPES_API_ENDPOINT}?page=${page}`, {
+      method: 'GET',
+      headers,
+    })
     const json = (await response.json()) as {
       error?: string
       field_types: FieldType[]
@@ -69,7 +82,7 @@ export const StoryblokClient: StoryblokClientFunc = (token) => {
 
   const updateFieldType: UpdateFieldTypeFunc = async ({ id, field_type }) => {
     const fetch = (await import('node-fetch')).default
-    const response = await fetch(`${PARTNER_FIELD_TYPES_API_ENDPOINT}${id}`, {
+    const response = await fetch(`${FIELD_TYPES_API_ENDPOINT}${id}`, {
       method: 'PUT',
       headers: headers,
       body: JSON.stringify({
@@ -82,7 +95,7 @@ export const StoryblokClient: StoryblokClientFunc = (token) => {
 
   const createFieldType: CreateFieldTypeFunc = async (body) => {
     const fetch = (await import('node-fetch')).default
-    const response = await fetch(`${PARTNER_FIELD_TYPES_API_ENDPOINT}`, {
+    const response = await fetch(`${FIELD_TYPES_API_ENDPOINT}`, {
       method: 'POST',
       headers,
       body: JSON.stringify({
@@ -97,6 +110,7 @@ export const StoryblokClient: StoryblokClientFunc = (token) => {
   }
 
   return {
+    isAuthenticated,
     fetchAllFieldTypes,
     updateFieldType,
     createFieldType,

--- a/packages/cli/src/storyblok/storyblok-client.ts
+++ b/packages/cli/src/storyblok/storyblok-client.ts
@@ -76,8 +76,8 @@ export const StoryblokClient: StoryblokClientFunc = (token) => {
         field_type,
       }),
     })
-    const json = (await response.json()) as FieldPluginResponse
-    handleErrorIfExists(response, json)
+    // The Update API returns an empty string as response body
+    handleErrorIfExists(response, {})
   }
 
   const createFieldType: CreateFieldTypeFunc = async (body) => {

--- a/packages/cli/src/storyblok/storyblok-client.ts
+++ b/packages/cli/src/storyblok/storyblok-client.ts
@@ -3,7 +3,7 @@ import type { Response } from 'node-fetch'
 
 export type FieldType = { id: number; name: string; body: string }
 
-export type Scope = 'my-space' | 'partner-portal'
+export type Scope = 'my-plugins' | 'partner-portal'
 
 type IsAuthenticatedFunc = () => Promise<boolean>
 

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env zx
+/* eslint-disable no-undef */
 
 import { $, which } from 'zx'
 import prompts from 'prompts'
@@ -74,12 +75,19 @@ try {
 }
 
 // Select which package to deploy ('field-plugin' | 'cli')
-const { packageFolder } = await prompts({
-  type: 'select',
-  name: 'packageFolder',
-  message: 'What to deploy?',
-  choices: PACKAGE_FOLDERS,
-})
+const { packageFolder } = await prompts(
+  {
+    type: 'select',
+    name: 'packageFolder',
+    message: 'What to deploy?',
+    choices: PACKAGE_FOLDERS,
+  },
+  {
+    onCancel: () => {
+      process.exit(1)
+    },
+  },
+)
 
 // Get the current version
 const { version: currentVersion, name: packageName } = JSON.parse(
@@ -94,27 +102,48 @@ const prerelease = semver.prerelease(currentVersion)
 let nextVersion
 if (prerelease) {
   // e.g. prerelease === ['alpha', 8]
-  const result = await prompts({
-    type: 'text',
-    name: 'nextVersion',
-    message: 'Next version?',
-    initial: semver.inc(currentVersion, 'prerelease', prerelease[0]),
-  })
+  const result = await prompts(
+    {
+      type: 'text',
+      name: 'nextVersion',
+      message: 'Next version?',
+      initial: semver.inc(currentVersion, 'prerelease', prerelease[0]),
+    },
+    {
+      onCancel: () => {
+        process.exit(1)
+      },
+    },
+  )
   nextVersion = result.nextVersion
 } else {
-  const { incrementLevel } = await prompts({
-    type: 'select',
-    name: 'incrementLevel',
-    message: 'Increment Level?',
-    choices: [{ value: 'patch' }, { value: 'minor' }, { value: 'major' }],
-  })
+  const { incrementLevel } = await prompts(
+    {
+      type: 'select',
+      name: 'incrementLevel',
+      message: 'Increment Level?',
+      choices: [{ value: 'patch' }, { value: 'minor' }, { value: 'major' }],
+    },
+    {
+      onCancel: () => {
+        process.exit(1)
+      },
+    },
+  )
 
-  const result = await prompts({
-    type: 'text',
-    name: 'nextVersion',
-    message: 'Next version?',
-    initial: semver.inc(currentVersion, incrementLevel),
-  })
+  const result = await prompts(
+    {
+      type: 'text',
+      name: 'nextVersion',
+      message: 'Next version?',
+      initial: semver.inc(currentVersion, incrementLevel),
+    },
+    {
+      onCancel: () => {
+        process.exit(1)
+      },
+    },
+  )
   nextVersion = result.nextVersion
 }
 


### PR DESCRIPTION
## What?
<!-- Mention the changes that are included in the PR -->

This PR enables support for both endpoints.
- https://mapi.storyblok.com/v1/partner_field_types/
- https://mapi.storyblok.com/v1/field_types/

It adds a new option `--scope` to the `deploy` command. It is prompted if not given.


---

This PR is a bit easier to review if you ignore whitespace changes.
![Screenshot 2023-04-17 at 13 28 39](https://user-images.githubusercontent.com/499898/232472014-179da26e-a31f-4a37-be3c-fc759b5a9bbb.png)
