### PR TITLE
EXT-1387: convert value to raw object for setValue in vue 3 template

### DIFF
--- a/packages/cli/templates/vue3/src/components/FieldPluginProvider.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPluginProvider.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { provide, reactive } from 'vue'
 import { createFieldPlugin, FieldPluginResponse } from '@storyblok/field-plugin'
+import { convertToRaw } from '../utils'
 
 const plugin = reactive<FieldPluginResponse>({
   type: 'loading',
@@ -9,7 +10,16 @@ createFieldPlugin((newState) => {
   plugin.type = newState.type
   plugin.error = newState.error
   plugin.data = newState.data
-  plugin.actions = newState.actions
+  if (newState.actions) {
+    plugin.actions = {
+      ...newState.actions,
+      setValue: (newValue: unknown) => {
+        newState.actions.setValue(convertToRaw(newValue))
+      },
+    }
+  } else {
+    plugin.actions = undefined
+  }
 })
 provide('field-plugin', plugin)
 </script>

--- a/packages/cli/templates/vue3/src/components/FieldPluginProvider.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPluginProvider.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { provide, reactive } from 'vue'
-import { createFieldPlugin, FieldPluginResponse } from '@storyblok/field-plugin'
+import {
+  createFieldPlugin,
+  FieldPluginResponse,
+  PluginState,
+} from '@storyblok/field-plugin'
 import { convertToRaw } from '../utils'
 
 const plugin = reactive<FieldPluginResponse>({
@@ -9,7 +13,28 @@ const plugin = reactive<FieldPluginResponse>({
 createFieldPlugin((newState) => {
   plugin.type = newState.type
   plugin.error = newState.error
-  plugin.data = newState.data
+
+  // Instead of replacing `plugin.data` which loses the reactive reference,
+  // we're assigning each property into `plugin.data`.
+  if (newState.type === 'loaded') {
+    if (plugin.data) {
+      const keys = Object.keys(newState.data) as Array<keyof PluginState>
+      keys.forEach((key) => {
+        if (typeof plugin.data[key] === 'object') {
+          // @ts-ignore not sure how to solve this
+          Object.assign(plugin.data[key], newState.data[key])
+        } else {
+          // @ts-ignore not sure how to solve this
+          plugin.data[key] = newState.data[key]
+        }
+      })
+    } else {
+      // @ts-ignore if `plugin.type` just became 'loaded', then `plugin.data` is still undefined.
+      // So this is a valid else-branch.
+      plugin.data = newState.data
+    }
+  }
+
   if (newState.actions) {
     plugin.actions = {
       ...newState.actions,

--- a/packages/cli/templates/vue3/src/utils/convertToRaw.ts
+++ b/packages/cli/templates/vue3/src/utils/convertToRaw.ts
@@ -1,26 +1,22 @@
 import { toRaw, isProxy, isRef, unref } from 'vue'
 
-export function convertToRaw(object: any) {
-  if (!isObject(object)) {
-    return object
+export function convertToRaw(value: any) {
+  let rawValue = value
+  if (isProxy(rawValue)) {
+    rawValue = toRaw(rawValue)
+  }
+  if (isRef(rawValue)) {
+    rawValue = unref(rawValue)
   }
 
-  let rawObject = object
-  if (isProxy(rawObject)) {
-    rawObject = toRaw(rawObject)
-  }
-  if (isRef(rawObject)) {
-    rawObject = unref(rawObject)
+  if (!isObject(rawValue)) {
+    return rawValue
   }
 
-  if (!isObject(rawObject)) {
-    return rawObject
-  }
-
-  return Object.keys(rawObject).reduce((result, key) => {
-    result[key] = convertToRaw(rawObject[key])
+  return Object.keys(rawValue).reduce((result, key) => {
+    result[key] = convertToRaw(rawValue[key])
     return result
-  }, rawObject)
+  }, rawValue)
 }
 
 function isObject(value: unknown) {

--- a/packages/cli/templates/vue3/src/utils/convertToRaw.ts
+++ b/packages/cli/templates/vue3/src/utils/convertToRaw.ts
@@ -9,14 +9,16 @@ export function convertToRaw(value: any) {
     rawValue = unref(rawValue)
   }
 
-  if (!isObject(rawValue)) {
+  if (isObject(rawValue)) {
+    return Object.keys(rawValue).reduce((result, key) => {
+      result[key] = convertToRaw(rawValue[key])
+      return result
+    }, rawValue)
+  } else if (Array.isArray(rawValue)) {
+    return rawValue.map(convertToRaw)
+  } else {
     return rawValue
   }
-
-  return Object.keys(rawValue).reduce((result, key) => {
-    result[key] = convertToRaw(rawValue[key])
-    return result
-  }, rawValue)
 }
 
 function isObject(value: unknown) {

--- a/packages/cli/templates/vue3/src/utils/convertToRaw.ts
+++ b/packages/cli/templates/vue3/src/utils/convertToRaw.ts
@@ -1,0 +1,28 @@
+import { toRaw, isProxy, isRef, unref } from 'vue'
+
+export function convertToRaw(object: any) {
+  if (!isObject(object)) {
+    return object
+  }
+
+  let rawObject = object
+  if (isProxy(rawObject)) {
+    rawObject = toRaw(rawObject)
+  }
+  if (isRef(rawObject)) {
+    rawObject = unref(rawObject)
+  }
+
+  if (!isObject(rawObject)) {
+    return rawObject
+  }
+
+  return Object.keys(rawObject).reduce((result, key) => {
+    result[key] = convertToRaw(rawObject[key])
+    return result
+  }, rawObject)
+}
+
+function isObject(value: unknown) {
+  return Object.prototype.toString.call(value) === '[object Object]'
+}

--- a/packages/cli/templates/vue3/src/utils/index.ts
+++ b/packages/cli/templates/vue3/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './convertToRaw'


### PR DESCRIPTION
## What?

This PR convert value to raw object that is being passed to setValue in vue 3 template.

## Why?

In Vue, Proxy is wildly used for its reactivity. And it’s a common case where user passes something reactive to setValue() method of Field Plugin library. Then postMessage fails because it cannot serialize the Proxy instance. So it’s necessary to un-proxy that object.

Also, we need to unref refs. Otherwise we will have unnecessary object instead of a simple value.

## How to test? (optional)

I changed `Counter` component to use both `ref` and `reactive` and confirmed that the value was correctly converted to a raw object.

![Screenshot 2023-04-17 at 14 49 06](https://user-images.githubusercontent.com/499898/232489143-de14a074-fb04-42d8-94bb-e6227769f0fb.png)

![Screenshot 2023-04-17 at 14 49 16](https://user-images.githubusercontent.com/499898/232489157-8e88a6e2-d296-4476-90cd-90f569d46780.png)
