### PR TITLE
EXT-1293: `add` command suggests `deploy` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build:lib": "yarn workspace @storyblok/field-plugin run build",
     "build": "yarn build:lib && yarn workspaces foreach --exclude @storyblok/field-plugin run build",
-    "build:container": "yarn build:lib && yarn workspace container run build",
+    "build:lib": "yarn workspace @storyblok/field-plugin build",
+    "build:cli": "yarn workspace @storyblok/field-plugin-cli build",
+    "build:container": "yarn build:lib && yarn workspace container build",
     "test": "jest",
     "check:types": "yarn workspaces foreach run check:types",
     "lint": "eslint .",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -142,7 +142,7 @@ export const add: AddFunc = async (args) => {
     console.log(`    >`, green(`yarn workspace ${packageName} dev`))
   }
 
-  console.log(`\n\n- To deploy the initial version to Storyblok:`)
+  console.log(`\n\n- To deploy the newly created field plugin to Storyblok:`)
   console.log(`    >`, green(`cd ${repoRootPath}`))
   if (structure === 'polyrepo') {
     console.log(`    >`, green(`yarn deploy`))

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,5 +1,4 @@
 import { bold, cyan, red, green } from 'kleur/colors'
-import prompts from 'prompts'
 import { resolve, dirname } from 'path'
 import {
   existsSync,
@@ -134,33 +133,21 @@ export const add: AddFunc = async (args) => {
     ).stdout,
   )
 
-  console.log('\n\n')
-  const { deploy } = await betterPrompts<{ deploy: boolean }>({
-    type: 'confirm',
-    initial: true,
-    name: 'deploy',
-    message: 'Do you want to deploy the initial version to Storyblok now?',
-  })
-  if (deploy) {
-    if (structure === 'polyrepo') {
-      await runCommand('yarn deploy', { cwd: repoRootPath })
-    } else if (structure === 'monorepo') {
-      await runCommand(`yarn workspace ${packageName} deploy`, {
-        cwd: repoRootPath,
-      })
-    }
-  }
-
   console.log(bold(cyan(`\n\nYour project \`${packageName}\` is ready 🚀\n`)))
   console.log(`- To run development mode run the following commands:`)
-
+  console.log(`    >`, green(`cd ${repoRootPath}`))
   if (structure === 'polyrepo') {
-    console.log(`    >`, green(`cd ${repoRootPath}`))
     console.log(`    >`, green(`yarn dev`))
   } else if (structure === 'monorepo') {
-    console.log(`    >`, green(`cd ${repoRootPath}`))
     console.log(`    >`, green(`yarn workspace ${packageName} dev`))
   }
 
+  console.log(`\n\n- To deploy the initial version to Storyblok:`)
+  console.log(`    >`, green(`cd ${repoRootPath}`))
+  if (structure === 'polyrepo') {
+    console.log(`    >`, green(`yarn deploy`))
+  } else if (structure === 'monorepo') {
+    console.log(`    >`, green(`yarn workspace ${packageName} deploy`))
+  }
   return { destPath }
 }


### PR DESCRIPTION
## What?

When there is a new package added (either as a polyrepo, or to a monorepo), now `add` command suggests user to deploy that initial version.

## Why?

If user deploys the field plugin right away, they will have the correct URL on the Storyblok side to test the field plugin. Also, it's always nice to have things set up in advance, rather than sweating with deployment after all the work.

Initially I was going to run the `deploy` command within `add` command directly, but it's maybe better to loosely display which command to run to deploy the field plugin. It might overwhelm users in the first place, even making a decision whether or not they want to deploy it right now.