### PR TITLE
EXT-1130: clarify --dir and --output options in deploy command

### DIFF
--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -1,4 +1,3 @@
-import prompts from 'prompts'
 import { createMonorepo, type CreateMonorepoArgs } from './monorepo'
 import { createPolyrepo, type CreatePolyrepoArgs } from './polyrepo'
 import { Structure } from '../add'

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -2,7 +2,12 @@ import { existsSync, readFileSync, lstatSync } from 'fs'
 import { bold, cyan, red, yellow, green } from 'kleur/colors'
 import { basename, resolve } from 'path'
 import { type Choice } from 'prompts'
-import { betterPrompts, getPersonalAccessToken, promptName } from '../utils'
+import {
+  betterPrompts,
+  getPersonalAccessToken,
+  isValidPackageName,
+  promptName,
+} from '../utils'
 import { Scope, StoryblokClient } from '../storyblok/storyblok-client'
 
 const packageNameMessage =
@@ -137,13 +142,23 @@ const decidePackageName = async ({
     return name
   }
 
+  const packageNameFromPackageJson = getPackageName(dir)
+
   if (skipPrompts) {
-    return getPackageName(dir)
+    if (isValidPackageName(packageNameFromPackageJson)) {
+      return packageNameFromPackageJson
+    } else {
+      console.log(red('[ERROR]'), 'The package name is missing')
+      console.log(
+        'Use `--name <package-name>` or `--dir <path-to-package>` to specify the package name.',
+      )
+      process.exit(1)
+    }
   }
 
   return await promptName({
     message: packageNameMessage,
-    initialValue: getPackageName(dir),
+    initialValue: packageNameFromPackageJson,
   })
 }
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -56,13 +56,13 @@ export const main = () => {
     .addOption(
       new Option(
         '--output <value>',
-        'defines location of the built output file',
+        'location of the built output file (default: `./dist/index.js`)',
       ),
     )
     .addOption(
       new Option(
         '--dir <value>',
-        'path to field plugin to be deployed',
+        `the path to your field plugin's \`package.json\` directory`,
       ).default('.'),
     )
     .addOption(

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -62,7 +62,7 @@ export const main = () => {
     .addOption(
       new Option(
         '--dir <value>',
-        `the path to your field plugin's \`package.json\` directory`,
+        `path to the field plugin's \`package.json\` directory`,
       ).default('.'),
     )
     .addOption(

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -114,6 +114,9 @@ export const getPersonalAccessToken: GetPersonalAccessTokenFunc = async ({
   }
 }
 
+export const isValidPackageName = (name: string): boolean =>
+  new RegExp(/^[a-z0-9\\-]+$/).test(name)
+
 export const promptName = async ({
   message,
   initialValue,
@@ -127,7 +130,7 @@ export const promptName = async ({
       name: 'name',
       message,
       initial: initialValue,
-      validate: (name: string) => new RegExp(/^[a-z0-9\\-]+$/).test(name),
+      validate: isValidPackageName,
     },
   ])
   return name


### PR DESCRIPTION
## What?

This PR clarifies `--dir` and `--output` options in deploy command.

