### PR TITLE
EXT-1453: Reset Value Button

### DIFF
--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -54,6 +54,7 @@ import { ValueView } from './ValueView'
 const uid = () => Math.random().toString(32).slice(2)
 
 const wrapperHost = 'localhost:7070'
+
 const defaultPluginOrigin = 'http://localhost:8080'
 
 const pluginParams: PluginUrlParams = {

--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -25,6 +25,7 @@ import {
   AccordionSummary,
   Alert,
   AlertTitle,
+  Box,
   Button,
   FormControl,
   IconButton,
@@ -37,6 +38,7 @@ import {
 import {
   ChevronDownIcon,
   ContentIcon,
+  DeleteIcon,
   RefreshIcon,
   SchemaIcon,
   useNotifications,
@@ -275,7 +277,25 @@ export const FieldPluginContainer: FunctionComponent = () => {
         </AccordionSummary>
         <AccordionDetails>
           <Stack gap={1}>
-            <Typography variant="h3">Value</Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+              }}
+            >
+              <Typography variant="h3">Value</Typography>
+              <Tooltip title="Reset value">
+                <IconButton
+                  aria-label="Reset value"
+                  color="secondary"
+                  size="small"
+                  onClick={() => setValue(undefined)}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              </Tooltip>
+            </Box>
             <ObjectDisplay output={value} />
             <Typography variant="h3">Height (px)</Typography>
             <ObjectDisplay output={height} />

--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -9,6 +9,7 @@ import {
 import {
   AssetSelectedMessage,
   ContextRequestMessage,
+  FieldPluginSchema,
   originFromPluginParams,
   PluginUrlParams,
   StateChangedMessage,
@@ -25,7 +26,6 @@ import {
   AccordionSummary,
   Alert,
   AlertTitle,
-  Box,
   Button,
   FormControl,
   IconButton,
@@ -38,7 +38,6 @@ import {
 import {
   ChevronDownIcon,
   ContentIcon,
-  DeleteIcon,
   RefreshIcon,
   SchemaIcon,
   useNotifications,
@@ -48,9 +47,9 @@ import { SchemaEditor } from './SchemaEditor'
 import { ObjectDisplay } from './ObjectDisplay'
 import { FieldTypePreview } from './FieldTypePreview'
 import { FlexTypography } from './FlexTypography'
-import { FieldPluginSchema } from '@storyblok/field-plugin'
 import { createContainerMessageListener } from '../dom/createContainerMessageListener'
 import { useDebounce } from 'use-debounce'
+import { ValueView } from './ValueView'
 
 const uid = () => Math.random().toString(32).slice(2)
 
@@ -277,48 +276,40 @@ export const FieldPluginContainer: FunctionComponent = () => {
         </AccordionSummary>
         <AccordionDetails>
           <Stack gap={1}>
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1,
-              }}
-            >
-              <Typography variant="h3">Value</Typography>
-              <Tooltip title="Reset value">
-                <IconButton
-                  aria-label="Reset value"
-                  color="secondary"
-                  size="small"
-                  onClick={() => setValue(undefined)}
-                >
-                  <DeleteIcon />
-                </IconButton>
-              </Tooltip>
-            </Box>
-            <ObjectDisplay output={value} />
-            <Typography variant="h3">Height (px)</Typography>
-            <ObjectDisplay output={height} />
-            <Typography variant="h3">Schema</Typography>
-            <ObjectDisplay output={schema} />
-            <Typography variant="h3">Is Modal?</Typography>
-            <ObjectDisplay output={isModal} />
-            <Typography variant="h3">Story</Typography>
-            <ObjectDisplay output={story} />
-            <Alert severity="info">
-              <AlertTitle>Note</AlertTitle>
-              Mutating the story does not automatically update the field plugin.
-              You need to click on the Request Context button. Click on the
-              button below to mutate the story.
-            </Alert>
-            <Button
-              onClick={onMutateStory}
-              size="small"
-              color="secondary"
-              endIcon={'+1'}
-            >
-              Mutate Story
-            </Button>
+            <ValueView
+              value={value}
+              setValue={setValue}
+            />
+            <Stack>
+              <Typography variant="h3">Height (px)</Typography>
+              <ObjectDisplay output={height} />
+            </Stack>
+            <Stack>
+              <Typography variant="h3">Schema</Typography>
+              <ObjectDisplay output={schema} />
+            </Stack>
+            <Stack>
+              <Typography variant="h3">Is Modal?</Typography>
+              <ObjectDisplay output={isModal} />
+            </Stack>
+            <Stack>
+              <Typography variant="h3">Story</Typography>
+              <ObjectDisplay output={story} />
+              <Alert severity="info">
+                <AlertTitle>Note</AlertTitle>
+                Mutating the story does not automatically update the field
+                plugin. You need to click on the Request Context button. Click
+                on the button below to mutate the story.
+              </Alert>
+              <Button
+                onClick={onMutateStory}
+                size="small"
+                color="secondary"
+                endIcon={'+1'}
+              >
+                Mutate Story
+              </Button>
+            </Stack>
           </Stack>
         </AccordionDetails>
       </Accordion>

--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -54,7 +54,6 @@ import { ValueView } from './ValueView'
 const uid = () => Math.random().toString(32).slice(2)
 
 const wrapperHost = 'localhost:7070'
-
 const defaultPluginOrigin = 'http://localhost:8080'
 
 const pluginParams: PluginUrlParams = {

--- a/packages/container/src/components/ValueView.tsx
+++ b/packages/container/src/components/ValueView.tsx
@@ -1,0 +1,33 @@
+import { FunctionComponent } from 'react'
+import { Box, IconButton, Stack, Tooltip, Typography } from '@mui/material'
+import { DeleteIcon } from '@storyblok/mui'
+import { ObjectDisplay } from './ObjectDisplay'
+
+export const ValueView: FunctionComponent<{
+  value: unknown
+  setValue: (value: unknown) => void
+}> = (props) => (
+  <Stack>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+      }}
+    >
+      <Typography variant="h3">Value</Typography>
+      <Tooltip title="Reset value">
+        <IconButton
+          aria-label="Reset value"
+          color="secondary"
+          size="small"
+          onClick={() => props.setValue(undefined)}
+        >
+          <DeleteIcon />
+        </IconButton>
+      </Tooltip>
+    </Box>
+
+    <ObjectDisplay output={props.value} />
+  </Stack>
+)


### PR DESCRIPTION
## What?

Added a button that lets the user reset the field plugin value. The initial value is `undefined`.

Extracted new component for displaying the value: ValueView.tsx. The same will be done for the other views (isModal, story, etc).

## Why?

This is not a big problem right now, because the value does not persist in between page reloads. But once we implement localStorage for the field plugin value, it will be necessary to have this functionality.

Notice how frustrating the field plugin editor in app.storyblok.com can be because it's not possible to reset the value to `undefined`. Developers need to hack their existing plugin, load a new plugin with the sole purpose of resetting the value, or use the MAPI.


## How to test? (optional)

Load a plugin in the preview deployment, set the value to something, and then click on the button.