### PR TITLE
EXT-1403-nicer-error-message-to-replace-the-one-from-the-failing-fieldtype-wrapper-js

### DIFF
--- a/packages/cli/templates/js/src/main.js
+++ b/packages/cli/templates/js/src/main.js
@@ -13,3 +13,8 @@ createFieldPlugin((response) => {
   buttonEl.textContent = `Increment: ${data.value ?? 0}`
   buttonEl.onclick = () => actions.setValue((data.value ?? 0) + 1)
 })
+
+// This error replaces another error which message is harder to understand and impossible to avoid util the issue https://github.com/storyblok/field-plugin/issues/107 has been resolved.
+throw new Error(
+  `This error can be safely ignored. It is caused by the legacy field plugin API. See issue https://github.com/storyblok/field-plugin/issues/107`,
+)

--- a/packages/cli/templates/react/src/main.tsx
+++ b/packages/cli/templates/react/src/main.tsx
@@ -8,3 +8,8 @@ const rootNode = createRootElement()
 document.body.appendChild(rootNode)
 
 createRoot(rootNode).render(<App />)
+
+// This error replaces another error which message is harder to understand and impossible to avoid util the issue https://github.com/storyblok/field-plugin/issues/107 has been resolved.
+throw new Error(
+  `This error can be safely ignored. It is caused by the legacy field plugin API. See issue https://github.com/storyblok/field-plugin/issues/107`,
+)

--- a/packages/cli/templates/vue2/src/main.ts
+++ b/packages/cli/templates/vue2/src/main.ts
@@ -1,12 +1,17 @@
-import Vue from 'vue';
-import App from './App.vue';
-import { initialModel } from './config';
+import Vue from 'vue'
+import App from './App.vue'
+import { initialModel } from './config'
 
-  new Vue({
-    render:(h) => h(App, {
+new Vue({
+  render: (h) =>
+    h(App, {
       props: {
         initialModel,
       },
-    })
-  }).$mount('#plugin')
+    }),
+}).$mount('#plugin')
 
+// This error replaces another error which message is harder to understand and impossible to avoid util the issue https://github.com/storyblok/field-plugin/issues/107 has been resolved.
+throw new Error(
+  `This error can be safely ignored. It is caused by the legacy field plugin API. See issue https://github.com/storyblok/field-plugin/issues/107`,
+)

--- a/packages/cli/templates/vue3/src/main.ts
+++ b/packages/cli/templates/vue3/src/main.ts
@@ -8,3 +8,8 @@ if (!document.querySelector('#app')) {
   document.body.appendChild(rootElement)
 }
 createApp(App).mount('#app')
+
+// This error replaces another error which message is harder to understand and impossible to avoid util the issue https://github.com/storyblok/field-plugin/issues/107 has been resolved.
+throw new Error(
+  `This error can be safely ignored. It is caused by the legacy field plugin API. See issue https://github.com/storyblok/field-plugin/issues/107`,
+)


### PR DESCRIPTION
## What?

Nicer error message from failing `fieldtype-wrapper.js`.

Replaces the uncaught error from https://github.com/storyblok/field-plugin/issues/107

<img width="773" alt="image" src="https://user-images.githubusercontent.com/14206504/234252646-138a2dd0-dcbc-4cb1-9dfa-b05a4d905392.png">

with

<img width="775" alt="image" src="https://user-images.githubusercontent.com/14206504/234252479-5bc0bd48-8078-4115-ad7f-03ddcf904f74.png">


## Why?

When a client upload code to the field plugin editor, Storyblok will serve a document with a script that contains that code. But the content of the script element will not be exactly the code that the client uploaded; it will be appended with a code snippet from Storyblok. For example, the if the client uploads

```javascript
console.log('hello')
``` 

Storyblok will serve a document with

```html
<script type="text/javascript">
  console.log('hello')

  var customComp = window.Storyblok.vue.extend(window.storyblok.field_types['sb-dummy'])
  window.Storyblok.vue.component('custom-plugin', customComp)
  window.StoryblokPluginRegistered = true
</script>
```

This last part causes an error to be thrown. The only way to prevent these last three lines from being executed is by throwing an error before it's executed.

For Storyblok internals, see the feature requests:

- Quick fix: https://storyblok.slack.com/archives/C03QMNGV3U1/p1682414222741019
- Permanent fix: https://storyblok.slack.com/archives/C03QMNGV3U1/p1680270175282369

## How to test? (optional)

Build one of the templates and upload the export bundle to the field plugin editor. You should see the new error message instead, and the app should load normally.