### PR TITLE
EXT-1464: Clear Console from Errors

### DIFF
--- a/packages/container/src/components/FieldTypePreview.tsx
+++ b/packages/container/src/components/FieldTypePreview.tsx
@@ -84,6 +84,7 @@ export const FieldTypePreview = forwardRef<
             ref={ref}
             key={props.uid}
             component="iframe"
+            src={props.src}
             title="Field Plugin Preview"
             style={{
               height: props.height,
@@ -91,7 +92,6 @@ export const FieldTypePreview = forwardRef<
               flex: 1,
               border: 'none',
             }}
-            {...props}
           />
         </FieldTypeContainer>
       </FieldTypeModal>


### PR DESCRIPTION
## What?

Fix the attributes on the iframe element. From spreading all `props` into the attributes to only setting the `src`.

## Why?

This would generate an error message, stating that the iframe element does not have an attribute called `isModal`.
