### PR TITLE
EXT-1451: Allow any URL for Previewed Field Plugins  

### DIFF
--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -26,6 +26,8 @@ import {
   Alert,
   AlertTitle,
   Button,
+  FormControl,
+  FormHelperText,
   IconButton,
   InputLabel,
   OutlinedInput,
@@ -53,7 +55,7 @@ import { useQueryParam, StringParam, withDefault } from 'use-query-params'
 const uid = () => Math.random().toString(32).slice(2)
 
 const wrapperHost = 'localhost:7070'
-const defaultOrigin = 'http://localhost:8080'
+const defaultUrl = 'http://localhost:8080'
 
 const pluginParams: PluginUrlParams = {
   uid: uid(),
@@ -64,15 +66,22 @@ const pluginParams: PluginUrlParams = {
 
 type TestStory = { content: { count: number } }
 
-const OriginQueryParam = withDefault(StringParam, defaultOrigin)
+const UrlQueryParam = withDefault(StringParam, defaultUrl)
 
 export const FieldPluginContainer: FunctionComponent = () => {
   const fieldTypeIframe = useRef<HTMLIFrameElement>(null)
-  const [origin, setOrigin] = useQueryParam('origin', OriginQueryParam)
+  const [url, setUrl] = useQueryParam('url', UrlQueryParam)
 
-  // Fall back to defaultOrigin when origin is an empty string; otherwise, the iframe will embedd the same origin, which will look strange.
-  const [debouncedOrigin] = useDebounce(origin || defaultOrigin, 1000)
-  const iframeSrc = `${debouncedOrigin}?${urlSearchParamsFromPluginUrlParams(
+  // Fall back to defaultUrl when the url is an empty string; otherwise, the iframe will embed the same origin, which will look strange.
+  const [debouncedUrl] = useDebounce(url, 1000)
+  const fieldPluginOrigin = useMemo<string | undefined>(() => {
+    try {
+      return new URL(debouncedUrl).origin
+    } catch {
+      return undefined
+    }
+  }, [debouncedUrl])
+  const iframeSrc = `${debouncedUrl}?${urlSearchParamsFromPluginUrlParams(
     pluginParams,
   )}`
   const [iframeUid, setIframeUid] = useState(uid)
@@ -126,10 +135,11 @@ export const FieldPluginContainer: FunctionComponent = () => {
   const postToPlugin = useCallback(
     (message: unknown) => {
       try {
-        fieldTypeIframe.current?.contentWindow?.postMessage(
-          message,
-          debouncedOrigin,
-        )
+        typeof fieldPluginOrigin !== 'undefined' &&
+          fieldTypeIframe.current?.contentWindow?.postMessage(
+            message,
+            fieldPluginOrigin,
+          )
       } catch (e) {
         error({
           title: 'Failed to post message to plugin',
@@ -137,7 +147,7 @@ export const FieldPluginContainer: FunctionComponent = () => {
         })
       }
     },
-    [error, debouncedOrigin],
+    [error, fieldPluginOrigin],
   )
 
   const dispatchStateChanged = useCallback(
@@ -196,19 +206,19 @@ export const FieldPluginContainer: FunctionComponent = () => {
           selectAsset: onAssetSelected,
         },
         {
-          iframeOrigin: debouncedOrigin,
+          iframeOrigin: fieldPluginOrigin,
           uid: pluginParams.uid,
           window,
         },
       ),
     [
-      debouncedOrigin,
       onLoaded,
       setValue,
       setHeight,
       setModal,
       onAssetSelected,
       onContextRequested,
+      fieldPluginOrigin,
     ],
   )
 
@@ -221,27 +231,32 @@ export const FieldPluginContainer: FunctionComponent = () => {
           </FlexTypography>
         </AccordionSummary>
         <AccordionDetails>
-          <FieldTypePreview
-            src={iframeSrc}
-            height={`${height}px`}
-            isModal={isModal}
-            ref={fieldTypeIframe}
-            uid={iframeUid}
-          />
+          {typeof fieldPluginOrigin !== 'undefined' && (
+            <FieldTypePreview
+              src={iframeSrc}
+              height={`${height}px`}
+              isModal={isModal}
+              ref={fieldTypeIframe}
+              uid={iframeUid}
+            />
+          )}
         </AccordionDetails>
         <AccordionActions sx={{ py: 8 }}>
-          <Stack>
-            <InputLabel htmlFor="plugin-origin">Plugin Origin</InputLabel>
+          <FormControl error={typeof fieldPluginOrigin === 'undefined'}>
+            <InputLabel
+              htmlFor="field-plugin-url"
+              shrink
+            >
+              Field Plugin URL
+            </InputLabel>
             <OutlinedInput
-              id="plugin-origin"
+              id="field-plugin-url"
+              aria-describedby="field-plugin-url-description"
               size="small"
-              label="Plugin Origin"
-              value={origin}
-              onChange={(e) => setOrigin(e.target.value)}
-              placeholder={defaultOrigin}
-              sx={{
-                width: '20em',
-              }}
+              label="Field Plugin URL"
+              value={url || undefined}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder={defaultUrl}
               endAdornment={
                 <Tooltip title="Reload plugin">
                   <IconButton
@@ -253,7 +268,10 @@ export const FieldPluginContainer: FunctionComponent = () => {
                 </Tooltip>
               }
             />
-          </Stack>
+            <FormHelperText id="my-helper-text">
+              Please enter a valid URL from where a field plugin is served.
+            </FormHelperText>
+          </FormControl>
         </AccordionActions>
       </Accordion>
       <Accordion>

--- a/packages/container/src/components/FieldTypePreview.tsx
+++ b/packages/container/src/components/FieldTypePreview.tsx
@@ -103,7 +103,6 @@ export const FieldTypePreview = forwardRef<
             <Alert
               severity="error"
               sx={{
-                height: props.height,
                 width: '100%',
               }}
             >

--- a/packages/container/src/components/FieldTypePreview.tsx
+++ b/packages/container/src/components/FieldTypePreview.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, FunctionComponent, PropsWithChildren } from 'react'
-import { Backdrop, Box } from '@mui/material'
+import { Alert, AlertTitle, Backdrop, Box, Typography } from '@mui/material'
 import { DisableShieldsNotification } from './DisableShieldsNotification'
 
 const FieldTypeModal: FunctionComponent<
@@ -32,6 +32,7 @@ const FieldTypeModal: FunctionComponent<
 const FieldTypeContainer: FunctionComponent<
   PropsWithChildren<{
     isModal: boolean
+    initialWidth: string
   }>
 > = (props) => (
   <Box
@@ -54,7 +55,7 @@ const FieldTypeContainer: FunctionComponent<
     }
     style={{
       margin: 'auto',
-      width: props.isModal ? '90%' : '300px',
+      width: props.isModal ? '90%' : props.initialWidth,
     }}
   >
     {props.children}
@@ -64,8 +65,9 @@ const FieldTypeContainer: FunctionComponent<
 export const FieldTypePreview = forwardRef<
   HTMLIFrameElement,
   {
-    src: string
+    src: string | undefined
     height: string
+    initialWidth: string
     isModal: boolean
     // Allows the iframe to be refreshed
     uid?: string
@@ -79,20 +81,36 @@ export const FieldTypePreview = forwardRef<
         sx={{ zIndex: ({ zIndex }) => zIndex.drawer }}
       />
       <FieldTypeModal isModal={props.isModal}>
-        <FieldTypeContainer isModal={props.isModal}>
-          <Box
-            ref={ref}
-            key={props.uid}
-            component="iframe"
-            src={props.src}
-            title="Field Plugin Preview"
-            style={{
-              height: props.height,
-              width: '100%',
-              flex: 1,
-              border: 'none',
-            }}
-          />
+        <FieldTypeContainer
+          isModal={props.isModal}
+          initialWidth={props.initialWidth}
+        >
+          {typeof props.src !== 'undefined' ? (
+            <Box
+              ref={ref}
+              key={props.uid}
+              component="iframe"
+              src={props.src}
+              title="Field Plugin Preview"
+              style={{
+                height: props.height,
+                width: '100%',
+                flex: 1,
+                border: 'none',
+              }}
+            />
+          ) : (
+            <Alert
+              severity="error"
+              sx={{
+                height: props.height,
+                width: '100%',
+              }}
+            >
+              <AlertTitle>Unable to Load Field Plugin</AlertTitle>
+              <Typography>Please enter a valid URL.</Typography>
+            </Alert>
+          )}
         </FieldTypeContainer>
       </FieldTypeModal>
     </>

--- a/packages/container/src/dom/createContainerMessageListener.ts
+++ b/packages/container/src/dom/createContainerMessageListener.ts
@@ -26,7 +26,7 @@ export type CreateContainerListener = (
   eventHandlers: ContainerActions,
   options: {
     window: Window
-    iframeOrigin: string
+    iframeOrigin: string | undefined
     uid: string
   },
 ) => () => void
@@ -56,7 +56,7 @@ export const createContainerMessageListener: CreateContainerListener = (
     } else if (isHeightChangeMessage(message)) {
       eventHandlers.setHeight(message.height)
     } else if (isAssetModalChangeMessage(message)) {
-      eventHandlers.selectAsset(message.field)
+      eventHandlers.selectAsset(message.field ?? '')
     } else if (isGetContextMessage(message)) {
       eventHandlers.requestContext()
     } else {


### PR DESCRIPTION
## What?

Let the user type in any URL. Before, the app would error if the provided value was not an origin (i.e. no path or query parameters were allowed).

The Sandbox now also displays a nicer error  message when the URL is invalid. There are three scenarios:

The URL points to a field plugin:

<img width="523" alt="image" src="https://user-images.githubusercontent.com/14206504/234308347-1a1ffe46-9fae-42ad-b8f5-923fe2f4fc01.png">
 
The URL is valid, but points to a URL where there is no field plugin hosted:

<img width="519" alt="image" src="https://user-images.githubusercontent.com/14206504/234308590-8cb3382b-7171-451a-9e58-c7c9b7cf92f5.png">

The URL is invalid:

<img width="613" alt="image" src="https://user-images.githubusercontent.com/14206504/234308703-daa39f90-cb19-4a81-acbf-d2f787ec2cd2.png">


## Why?


The container compared the origin of the message with the value that the user specified in the container's "Origin" field.

Because URLs with trailing slashes are not valid origins, the message origin from the field plugin would not match the value that the user specified in the conrtainer, causing the container to ignore all message. For example,`http://localhost:8080/` and `http://localhost:8080/base-url` would not equal the origin of the message, `http://localhost:8080`.

## How to test? (optional)

Open the sandbox from the preview deployment below in this pull request.

Under _Preview_ > _Field Plugin URL_, type

`https://storyblok-bynder.vercel.app/`

The field plugin should load.

Type an invalid URL, such as an empty string, invalid origin, or invalid protocol. You should see 

<img width="613" alt="image" src="https://user-images.githubusercontent.com/14206504/234309248-e9922712-df8b-4a96-a65d-91a8fcf679a2.png">
