### PR TITLE
EXT-1474-guide-the-user-to-the-sandbox-if-the-app-is-not-embedded

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -4,6 +4,7 @@ import { disableDefaultStoryblokStyles } from './disableDefaultStoryblokStyles'
 import { pluginUrlParamsFromUrl } from '../messaging'
 import { FieldPluginResponse } from './FieldPluginResponse'
 import { createPluginMessageListener } from './createPluginActions/createPluginMessageListener'
+import { sandboxUrl } from './sandboxUrl'
 
 export type CreateFieldPlugin = (
   onUpdate: (state: FieldPluginResponse) => void,
@@ -18,7 +19,9 @@ export const createFieldPlugin: CreateFieldPlugin = (onUpdateState) => {
   if (!isEmbedded) {
     onUpdateState({
       type: 'error',
-      error: new Error(`The window is not embedded within another window`),
+      error: new Error(
+        `The window is not embedded within another window. Did you mean to open the field plugin in the sandbox? ${sandboxUrl()}`,
+      ),
     })
     return () => undefined
   }

--- a/packages/field-plugin/src/createFieldPlugin/sandboxUrl.ts
+++ b/packages/field-plugin/src/createFieldPlugin/sandboxUrl.ts
@@ -1,0 +1,7 @@
+const sandboxBaseUrl = `https://storyblok-field-plugin-sandbox.vercel.app/`
+export const sandboxUrl = () => {
+  const sandboxQuery = new URLSearchParams({
+    url: window.location.href,
+  }).toString()
+  return `${sandboxBaseUrl}?${sandboxQuery}`
+}


### PR DESCRIPTION
## What?

If the app is not embedded, the error message that `createFieldPlugin()` returns references the sandbox:



## Why?

Even though the Vite `print-plugin` prints out the URL to the sandbox, the user might still open the field plugin directly, causing the app to fail to load. 

## How to test? (optional)
