### PR TITLE
EXT-1476: Replace toBeTruthy and toBeFalsy with equality check

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/createAutoResizer.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createAutoResizer.test.ts
@@ -48,7 +48,7 @@ describe('auto resizer', () => {
     })
     createAutoResizer(uid, postToContainer)
     mockResize()
-    expect(isHeightChangeMessage(message)).toBeTruthy()
+    expect(isHeightChangeMessage(message)).toEqual(true)
   })
   it('posts the right height to the container', () => {
     const { mockResize } = mockResizeObserver()

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/AssetSelectedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/AssetSelectedMessage.test.ts
@@ -12,7 +12,7 @@ const stub: AssetSelectedMessage = {
 
 describe('AssetSelectedMessage', function () {
   it('is a message to plugin', () => {
-    expect(isAssetSelectedMessage(stub)).toBeTruthy()
+    expect(isAssetSelectedMessage(stub)).toEqual(true)
   })
   describe('the action property', () => {
     it('equals "asset-selected"', () => {
@@ -21,13 +21,13 @@ describe('AssetSelectedMessage', function () {
           ...stub,
           action: 'asset-selected',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isAssetSelectedMessage({
           ...stub,
           action: 'something-else',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('the field property', () => {
@@ -38,7 +38,7 @@ describe('AssetSelectedMessage', function () {
           uid: '-preview',
           filename: 'https://somthing.com/myimage.jpg',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
     })
     it('can be undefined', () => {
       expect(
@@ -46,7 +46,7 @@ describe('AssetSelectedMessage', function () {
           ...stub,
           field: undefined,
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
     })
     it('is a string', () => {
       expect(
@@ -54,37 +54,37 @@ describe('AssetSelectedMessage', function () {
           ...stub,
           field: 'any-string',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isAssetSelectedMessage({
           ...stub,
           field: 123,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isAssetSelectedMessage({
           ...stub,
           field: null,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isAssetSelectedMessage({
           ...stub,
           field: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isAssetSelectedMessage({
           ...stub,
           field: {},
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isAssetSelectedMessage({
           ...stub,
           field: false,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('the filename property', () => {
@@ -94,13 +94,13 @@ describe('AssetSelectedMessage', function () {
           ...stub,
           filename: 'any-string',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isAssetSelectedMessage({
           ...stub,
           filename: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     it('is a string', () => {
       expect(
@@ -108,43 +108,43 @@ describe('AssetSelectedMessage', function () {
           ...stub,
           filename: 'any-string',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isAssetSelectedMessage({
           ...stub,
           filename: 123,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isAssetSelectedMessage({
           ...stub,
           filename: null,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isAssetSelectedMessage({
           ...stub,
           filename: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isAssetSelectedMessage({
           ...stub,
           filename: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isAssetSelectedMessage({
           ...stub,
           filename: {},
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isAssetSelectedMessage({
           ...stub,
           filename: false,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/FieldPluginSchema.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/FieldPluginSchema.test.ts
@@ -12,12 +12,12 @@ describe('field plugin schema', () => {
           name: 'a',
           value: 'a',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isFieldPluginOption({
           value: 'a',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that the "name" property is a string', () => {
       expect(
@@ -25,43 +25,43 @@ describe('field plugin schema', () => {
           name: 'a',
           value: 'a',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isFieldPluginOption({
           name: undefined,
           value: 'a',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: null,
           value: 'a',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: 123,
           value: 'a',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: true,
           value: 'a',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: [],
           value: 'a',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: {},
           value: 'a',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that the "value" property is required', () => {
       expect(
@@ -69,12 +69,12 @@ describe('field plugin schema', () => {
           name: 'a',
           value: 'a',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isFieldPluginOption({
           name: 'a',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that the "value" property is a string', () => {
       expect(
@@ -82,43 +82,43 @@ describe('field plugin schema', () => {
           name: 'a',
           value: 'a',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isFieldPluginOption({
           name: 'a',
           value: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: 'a',
           value: null,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: 'a',
           value: 123,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: 'a',
           value: true,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: 'a',
           value: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginOption({
           name: 'a',
           value: {},
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('field plugin option', () => {
@@ -128,12 +128,12 @@ describe('field plugin schema', () => {
           field_type: 'field-type-name',
           options: [],
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isFieldPluginSchema({
           options: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that the "field_type" property is a string', () => {
       expect(
@@ -141,43 +141,43 @@ describe('field plugin schema', () => {
           field_type: 'field-type-name',
           options: [],
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isFieldPluginSchema({
           field_type: undefined,
           options: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: null,
           options: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: 123,
           options: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: true,
           options: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: {},
           options: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: [],
           options: [],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that the "options" property is required', () => {
       expect(
@@ -185,12 +185,12 @@ describe('field plugin schema', () => {
           field_type: 'field-type-name',
           options: [],
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isFieldPluginSchema({
           field_type: 'field-type-name',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that the "options" property is an array', () => {
       expect(
@@ -198,43 +198,43 @@ describe('field plugin schema', () => {
           field_type: 'field-type-name',
           options: [],
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: null,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: {},
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: 'a',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: 123,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: true,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that the "options" property is an array of FieldPluginOptions', () => {
       const option: FieldPluginOption = {
@@ -246,13 +246,13 @@ describe('field plugin schema', () => {
           field_type: 'name',
           options: [option],
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isFieldPluginSchema({
           field_type: 'name',
           options: [{}],
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/MessageToPlugin.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/MessageToPlugin.test.ts
@@ -13,13 +13,13 @@ describe('message from plugin to container', () => {
           ...stub,
           uid: 'abc',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isMessageToPlugin({
           ...stub,
           uid: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     it('is a string', () => {
       expect(
@@ -27,19 +27,19 @@ describe('message from plugin to container', () => {
           ...stub,
           uid: 'abc',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isMessageToPlugin({
           ...stub,
           uid: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isMessageToPlugin({
           ...stub,
           uid: 123,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('the action property', () => {
@@ -49,13 +49,13 @@ describe('message from plugin to container', () => {
           ...stub,
           action: 'any-string',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isMessageToPlugin({
           ...stub,
           action: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     it('is a string', () => {
       expect(
@@ -63,37 +63,37 @@ describe('message from plugin to container', () => {
           ...stub,
           action: 'any-string',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isMessageToPlugin({
           ...stub,
           action: 123,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isMessageToPlugin({
           ...stub,
           action: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isMessageToPlugin({
           ...stub,
           action: true,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isMessageToPlugin({
           ...stub,
           action: false,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isMessageToPlugin({
           ...stub,
           action: null,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.test.ts
@@ -19,7 +19,7 @@ const stub: StateChangedMessage = {
 
 describe('StateChangedMessage', () => {
   it('should validate', () => {
-    expect(isStateChangedMessage(stub)).toBeTruthy()
+    expect(isStateChangedMessage(stub)).toEqual(true)
   })
   describe('The "action" property', () => {
     it('equals "loaded"', () => {
@@ -28,7 +28,7 @@ describe('StateChangedMessage', () => {
           ...stub,
           action: 'anotherString',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('the "uid" property', () => {
@@ -38,7 +38,7 @@ describe('StateChangedMessage', () => {
           ...stub,
           uid: 'anything',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
     })
     it('is not undefined', () => {
       expect(
@@ -46,7 +46,7 @@ describe('StateChangedMessage', () => {
           ...stub,
           uid: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     it('is not null', () => {
       expect(
@@ -54,7 +54,7 @@ describe('StateChangedMessage', () => {
           ...stub,
           uid: null,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     it('is not a number', () => {
       expect(
@@ -62,7 +62,7 @@ describe('StateChangedMessage', () => {
           ...stub,
           uid: 123,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('The "schema" property', () => {
@@ -72,7 +72,7 @@ describe('StateChangedMessage', () => {
           ...stub,
           schema: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     it('must be a schema', () => {
       expect(
@@ -88,7 +88,7 @@ describe('StateChangedMessage', () => {
             ],
           } as FieldPluginSchema,
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
     })
   })
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StoryData.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StoryData.test.ts
@@ -3,25 +3,25 @@ import { isStoryData, StoryData } from './StoryData'
 describe('StoryData', () => {
   describe('validation', () => {
     it('is an object', () => {
-      expect(isStoryData({ content: {} })).toBeTruthy()
-      expect(isStoryData([])).toBeFalsy()
-      expect(isStoryData('')).toBeFalsy()
-      expect(isStoryData(1)).toBeFalsy()
-      expect(isStoryData(undefined)).toBeFalsy()
-      expect(isStoryData(null)).toBeFalsy()
-      expect(isStoryData(() => undefined)).toBeFalsy()
+      expect(isStoryData({ content: {} })).toEqual(true)
+      expect(isStoryData([])).toEqual(false)
+      expect(isStoryData('')).toEqual(false)
+      expect(isStoryData(1)).toEqual(false)
+      expect(isStoryData(undefined)).toEqual(false)
+      expect(isStoryData(null)).toEqual(false)
+      expect(isStoryData(() => undefined)).toEqual(false)
     })
     it('requires a content property', () => {
-      expect(isStoryData({ content: {} })).toBeTruthy()
-      expect(isStoryData({})).toBeFalsy()
+      expect(isStoryData({ content: {} })).toEqual(true)
+      expect(isStoryData({})).toEqual(false)
     })
     it('requires the content property to be an object', () => {
-      expect(isStoryData({ content: {} })).toBeTruthy()
-      expect(isStoryData({ content: [] })).toBeFalsy()
-      expect(isStoryData({ content: 1 })).toBeFalsy()
-      expect(isStoryData({ content: '' })).toBeFalsy()
-      expect(isStoryData({ content: undefined })).toBeFalsy()
-      expect(isStoryData({ content: null })).toBeFalsy()
+      expect(isStoryData({ content: {} })).toEqual(true)
+      expect(isStoryData({ content: [] })).toEqual(false)
+      expect(isStoryData({ content: 1 })).toEqual(false)
+      expect(isStoryData({ content: '' })).toEqual(false)
+      expect(isStoryData({ content: undefined })).toEqual(false)
+      expect(isStoryData({ content: null })).toEqual(false)
     })
     it('can have unknown properties', () => {
       expect(
@@ -29,7 +29,7 @@ describe('StoryData', () => {
           content: {},
           someProps: 'someValue',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
     })
     test('that the content have unknown properties', () => {
       expect(
@@ -38,7 +38,7 @@ describe('StoryData', () => {
             someProps: 'someValue',
           },
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
     })
   })
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/AssetModalChangeMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/AssetModalChangeMessage.test.ts
@@ -16,14 +16,14 @@ const stub: AssetModalChangeMessage = {
 describe('AssetModalChangeMessage', () => {
   describe('validator', () => {
     it('should be an event showAssetModal', () => {
-      expect(isAssetModalChangeMessage(stub)).toBeTruthy()
-      expect(
-        isAssetModalChangeMessage({ ...stub, event: 'wrong-event' }),
-      ).toBeFalsy()
-      expect(
-        isAssetModalChangeMessage({ ...stub, event: undefined }),
-      ).toBeFalsy()
-      expect(isAssetModalChangeMessage({ ...stub, event: null })).toBeFalsy()
+      expect(isAssetModalChangeMessage(stub)).toEqual(true)
+      expect(isAssetModalChangeMessage({ ...stub, event: 'wrong-event' })).toBe(
+        false,
+      )
+      expect(isAssetModalChangeMessage({ ...stub, event: undefined })).toBe(
+        false,
+      )
+      expect(isAssetModalChangeMessage({ ...stub, event: null })).toEqual(false)
     })
     describe('field property', () => {
       it('is optional', () => {
@@ -33,19 +33,21 @@ describe('AssetModalChangeMessage', () => {
             uid,
             event: 'showAssetModal',
           }),
-        ).toBeTruthy()
+        ).toEqual(true)
       })
       it('can be undefined', () => {
-        expect(
-          isAssetModalChangeMessage({ ...stub, field: undefined }),
-        ).toBeTruthy()
+        expect(isAssetModalChangeMessage({ ...stub, field: undefined })).toBe(
+          true,
+        )
       })
       it('is a string', () => {
         expect(
           isAssetModalChangeMessage({ ...stub, field: 'any-string' }),
-        ).toBeTruthy()
-        expect(isAssetModalChangeMessage({ ...stub, field: 1 })).toBeFalsy()
-        expect(isAssetModalChangeMessage({ ...stub, field: null })).toBeFalsy()
+        ).toEqual(true)
+        expect(isAssetModalChangeMessage({ ...stub, field: 1 })).toEqual(false)
+        expect(isAssetModalChangeMessage({ ...stub, field: null })).toEqual(
+          false,
+        )
       })
     })
   })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/GetContextMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/GetContextMessage.test.ts
@@ -15,7 +15,7 @@ const stub: GetContextMessage = {
 describe('ValueChangeMessage', () => {
   describe('validator', () => {
     it('is a MessageToContainer', () => {
-      expect(isMessageToContainer(stub)).toBeTruthy()
+      expect(isMessageToContainer(stub)).toEqual(true)
     })
     it('requires event to be "getContext"', () => {
       expect(
@@ -23,13 +23,13 @@ describe('ValueChangeMessage', () => {
           ...stub,
           event: 'getContext',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isGetContextMessage({
           ...stub,
           event: 'somethingElse',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('constructor', () => {

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/HeightChangeMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/HeightChangeMessage.test.ts
@@ -17,7 +17,7 @@ const stub: HeightChangeMessage = {
 describe('isHeightChangeMessage', () => {
   describe('validator', () => {
     it('is a MessageToContainer', () => {
-      expect(isMessageToContainer(stub)).toBeTruthy()
+      expect(isMessageToContainer(stub)).toEqual(true)
     })
     it('requires event to be "heightChange"', () => {
       expect(
@@ -25,28 +25,28 @@ describe('isHeightChangeMessage', () => {
           ...stub,
           event: 'heightChange',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isHeightChangeMessage({
           ...stub,
           event: 'somethingElse',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that height is a number', () => {
-      expect(isHeightChangeMessage(stub)).toBeTruthy()
+      expect(isHeightChangeMessage(stub)).toEqual(true)
       expect(
         isHeightChangeMessage({
           ...stub,
           height: '100vw',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isHeightChangeMessage({
           ...stub,
           height: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('constructor', () => {

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/MessageToContainer.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/MessageToContainer.test.ts
@@ -17,25 +17,25 @@ describe('message from plugin to container', () => {
             ...stub,
             action: 'plugin-changed',
           }),
-        ).toBeTruthy()
+        ).toEqual(true)
         expect(
           isMessageToContainer({
             ...stub,
             action: 'something-different',
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
         expect(
           isMessageToContainer({
             ...stub,
             action: undefined,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
         expect(
           isMessageToContainer({
             ...stub,
             action: 123,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
       })
     })
     describe('the uid property', () => {
@@ -45,13 +45,13 @@ describe('message from plugin to container', () => {
             ...stub,
             uid: 'abc',
           }),
-        ).toBeTruthy()
+        ).toEqual(true)
         expect(
           isMessageToContainer({
             ...stub,
             uid: undefined,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
       })
       it('requires uid to be a string', () => {
         expect(
@@ -59,19 +59,19 @@ describe('message from plugin to container', () => {
             ...stub,
             uid: 'abc',
           }),
-        ).toBeTruthy()
+        ).toEqual(true)
         expect(
           isMessageToContainer({
             ...stub,
             uid: undefined,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
         expect(
           isMessageToContainer({
             ...stub,
             uid: 123,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
       })
     })
     describe('the event property', () => {
@@ -81,37 +81,37 @@ describe('message from plugin to container', () => {
             ...stub,
             event: 'any-string',
           }),
-        ).toBeTruthy()
+        ).toEqual(true)
         expect(
           isMessageToContainer({
             ...stub,
             event: 123,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
         expect(
           isMessageToContainer({
             ...stub,
             event: undefined,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
         expect(
           isMessageToContainer({
             ...stub,
             event: true,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
         expect(
           isMessageToContainer({
             ...stub,
             event: false,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
         expect(
           isMessageToContainer({
             ...stub,
             event: null,
           }),
-        ).toBeFalsy()
+        ).toEqual(false)
       })
     })
   })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/ModalChangeMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/ModalChangeMessage.test.ts
@@ -16,7 +16,7 @@ const stub: ModalChangeMessage = {
 describe('ModalChangeMessage', () => {
   describe('validator', () => {
     it('is a MessageToContainer', () => {
-      expect(isMessageToContainer(stub)).toBeTruthy()
+      expect(isMessageToContainer(stub)).toEqual(true)
     })
     it('requires event to be "toggleModal"', () => {
       expect(
@@ -24,13 +24,13 @@ describe('ModalChangeMessage', () => {
           ...stub,
           event: 'toggleModal',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isModalChangeMessage({
           ...stub,
           event: 'somethingElse',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     it('has a status', () => {
       expect(
@@ -38,13 +38,13 @@ describe('ModalChangeMessage', () => {
           ...stub,
           status: true,
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isModalChangeMessage({
           ...stub,
           status: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that the status is a boolean', () => {
       expect(
@@ -52,37 +52,37 @@ describe('ModalChangeMessage', () => {
           ...stub,
           status: true,
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isModalChangeMessage({
           ...stub,
           status: false,
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isModalChangeMessage({
           ...stub,
           status: 'false',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isModalChangeMessage({
           ...stub,
           status: 123,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isModalChangeMessage({
           ...stub,
           status: null,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
       expect(
         isModalChangeMessage({
           ...stub,
           status: undefined,
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('constructor', () => {

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
@@ -15,7 +15,7 @@ const stub: PluginLoadedMessage = {
 describe('PluginLoadedMessage', () => {
   describe('validator', () => {
     it('is a MessageToContainer', () => {
-      expect(isMessageToContainer(stub)).toBeTruthy()
+      expect(isMessageToContainer(stub)).toEqual(true)
     })
     it('requires event to be "loaded"', () => {
       expect(
@@ -23,13 +23,13 @@ describe('PluginLoadedMessage', () => {
           ...stub,
           event: 'loaded',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isPluginLoadedMessage({
           ...stub,
           event: 'somethingElse',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
   })
   describe('constructor', () => {

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/ValueChangeMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/ValueChangeMessage.test.ts
@@ -16,7 +16,7 @@ const stub: ValueChangeMessage = {
 describe('ValueChangeMessage', () => {
   describe('validator', () => {
     it('is a MessageToContainer', () => {
-      expect(isMessageToContainer(stub)).toBeTruthy()
+      expect(isMessageToContainer(stub)).toEqual(true)
     })
     it('requires event to be "update"', () => {
       expect(
@@ -24,17 +24,17 @@ describe('ValueChangeMessage', () => {
           ...stub,
           event: 'update',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isValueChangeMessage({
           ...stub,
           event: 'somethingElse',
         }),
-      ).toBeFalsy()
+      ).toEqual(false)
     })
     test('that the model property is present', () => {
       const { model: _, ...withoutModel } = stub
-      expect(isValueChangeMessage(withoutModel)).toBeFalsy()
+      expect(isValueChangeMessage(withoutModel)).toEqual(false)
     })
     test('that the model property can be any value', () => {
       expect(
@@ -42,43 +42,43 @@ describe('ValueChangeMessage', () => {
           ...stub,
           model: undefined,
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isValueChangeMessage({
           ...stub,
           model: null,
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isValueChangeMessage({
           ...stub,
           model: {},
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isValueChangeMessage({
           ...stub,
           model: 'a string',
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isValueChangeMessage({
           ...stub,
           model: true,
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isValueChangeMessage({
           ...stub,
           model: 123.123,
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
       expect(
         isValueChangeMessage({
           ...stub,
           model: [],
         }),
-      ).toBeTruthy()
+      ).toEqual(true)
     })
   })
   describe('constructor', () => {

--- a/packages/field-plugin/src/utils/hasKey/hasKey.test.ts
+++ b/packages/field-plugin/src/utils/hasKey/hasKey.test.ts
@@ -2,27 +2,27 @@ import { hasKey } from './hasKey'
 
 describe('hasKey', () => {
   it('should be false for numbers', () => {
-    expect(hasKey(123, 'myKey')).toBeFalsy()
+    expect(hasKey(123, 'myKey')).toEqual(false)
   })
   it('should be false for strings', () => {
-    expect(hasKey(123, 'string')).toBeFalsy()
+    expect(hasKey(123, 'string')).toEqual(false)
   })
   it('should be  false for arrays', () => {
-    expect(hasKey([1, 2, 3], 'myKey')).toBeFalsy()
+    expect(hasKey([1, 2, 3], 'myKey')).toEqual(false)
   })
   it('should be false for undefined', () => {
-    expect(hasKey(undefined, 'myKey')).toBeFalsy()
+    expect(hasKey(undefined, 'myKey')).toEqual(false)
   })
   it('should be false for null', () => {
-    expect(hasKey(null, 'myKey')).toBeFalsy()
+    expect(hasKey(null, 'myKey')).toEqual(false)
   })
   it('should be false for object when key does not exist', () => {
-    expect(hasKey({ a: 1 }, 'myKey')).toBeFalsy()
+    expect(hasKey({ a: 1 }, 'myKey')).toEqual(false)
   })
   it('should be true for object when key exist', () => {
-    expect(hasKey({ myKey: 1 }, 'myKey')).toBeTruthy()
+    expect(hasKey({ myKey: 1 }, 'myKey')).toEqual(true)
   })
   it('should be true for object when key exist with other properties', () => {
-    expect(hasKey({ a: 1, myKey: 1 }, 'myKey')).toBeTruthy()
+    expect(hasKey({ a: 1, myKey: 1 }, 'myKey')).toEqual(true)
   })
 })


### PR DESCRIPTION
## What?

In the tests for the library, replace 

- `toBeTruthy` with `toEqual(true)`
- `toBeFalsy` with `toEqual(false)`

## Why?

To not fall victim of type coercion. These functions should all return boolean values.

## How to test? (optional)

```
yarn workspace @storyblok/field-plugin test
```