### PR TITLE
chore: fix bump-version script

### DIFF
--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -62,17 +62,17 @@ if (currentBranch.toString().trim() !== 'main') {
 }
 
 // Check if the working directory is clean
-// try {
-//   await $`git diff-index --quiet HEAD --`
-// } catch (processOutput) {
-//   if (processOutput.exitCode === 1) {
-//     print(
-//       bold(red('[Error]')),
-//       'There are uncommitted changes in the working directory. Please clean them up before proceeding.',
-//     )
-//     exit(1)
-//   }
-// }
+try {
+  await $`git diff-index --quiet HEAD --`
+} catch (processOutput) {
+  if (processOutput.exitCode === 1) {
+    print(
+      bold(red('[Error]')),
+      'There are uncommitted changes in the working directory. Please clean them up before proceeding.',
+    )
+    exit(1)
+  }
+}
 
 // Select which package to deploy ('field-plugin' | 'cli')
 const { packageFolder } = await prompts(

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -62,17 +62,17 @@ if (currentBranch.toString().trim() !== 'main') {
 }
 
 // Check if the working directory is clean
-try {
-  await $`git diff-index --quiet HEAD --`
-} catch (processOutput) {
-  if (processOutput.exitCode === 1) {
-    print(
-      bold(red('[Error]')),
-      'There are uncommitted changes in the working directory. Please clean them up before proceeding.',
-    )
-    exit(1)
-  }
-}
+// try {
+//   await $`git diff-index --quiet HEAD --`
+// } catch (processOutput) {
+//   if (processOutput.exitCode === 1) {
+//     print(
+//       bold(red('[Error]')),
+//       'There are uncommitted changes in the working directory. Please clean them up before proceeding.',
+//     )
+//     exit(1)
+//   }
+// }
 
 // Select which package to deploy ('field-plugin' | 'cli')
 const { packageFolder } = await prompts(
@@ -160,7 +160,7 @@ const branchName = `chore/release-${packageFolder}-${nextVersion}`
 await $`git checkout -b ${branchName}`
 
 // Update the version
-await $`cd packages/${packageFolder} && npm version ${nextVersion} --no-git-tag-version`
+await $`cd packages/${packageFolder} && npm version ${nextVersion} --no-git-tag-version --workspaces --no-workspaces-update`
 await $`yarn install`
 
 // Create a pull-request


### PR DESCRIPTION
## What?

This PR fixes `bump-version` script.

## Why?

It uses `npm version` command to update the `version` in `package.json` file, but it fails with this error message.

```
npm ERR! code EUNSUPPORTEDPROTOCOL
npm ERR! Unsupported URL Type "workspace:": workspace:*

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/eunjae/.npm/_logs/2023-04-27T07_55_00_345Z-debug-0.log
Error: npm ERR! code EUNSUPPORTEDPROTOCOL
npm ERR! Unsupported URL Type "workspace:": workspace:*

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/eunjae/.npm/_logs/2023-04-27T07_55_00_345Z-debug-0.log
    at file:///Users/eunjae/workspace/field-plugin/scripts/bump-version.mjs:163:8
    exit code: 1
```

We have some dependencies like:

```
"@storyblok/field-plugin": "workspace:*"
```

I think it's better to change that in the long run, but anyway I'm making change here first.

## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->