### PR TITLE
EXT-1481: Sync Data When Changed in the Container

### DIFF
--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -186,6 +186,9 @@ export const FieldPluginContainer: FunctionComponent = () => {
   const onLoaded = useCallback(() => {
     dispatchStateChanged(loadedData)
   }, [dispatchStateChanged, loadedData])
+
+  useEffect(onLoaded, [onLoaded])
+
   const onContextRequested = useCallback(
     () =>
       dispatchContextRequest({


### PR DESCRIPTION
## What?

When the developer change the state in the container, the new state is sent to the field plugin.

In the example, notice how the text on the button changes in real-time:

![2023-04-27_11-23-57 (1)](https://user-images.githubusercontent.com/14206504/234819759-8c2b635b-ba83-49e0-8f01-22d5a920b92b.gif)


## Why?

When the user would change the options, they would have to manually refresh the plugin.

