### PR TITLE
EXT-1302: show shorter path for created repository

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -1,15 +1,19 @@
 import { existsSync } from 'fs'
 import { vi } from 'vitest'
-import { getPersonalAccessToken } from '../utils'
+import { getPersonalAccessToken, checkIfSubDir } from '../utils'
 
-vi.mock('node:fs', () => {
+vi.mock('node:fs', async () => {
+  const mod = await vi.importActual<typeof import('fs')>('fs')
   return {
+    ...mod,
     existsSync: vi.fn(),
   }
 })
 
-vi.mock('node:path', () => {
+vi.mock('node:path', async () => {
+  const mod = await vi.importActual<typeof import('path')>('path')
   return {
+    ...mod,
     resolve: (path: string) => `<current-directory>/${path}`,
   }
 })
@@ -115,6 +119,18 @@ describe('utils', () => {
           token: 'my-token',
         })
       })
+    })
+  })
+
+  describe('checkIfSubDir', () => {
+    it('returns true for sub dir', () => {
+      expect(checkIfSubDir('/abc', '/abc/def')).toBe(true)
+      expect(checkIfSubDir('/abc/', '/abc/def')).toBe(true)
+    })
+
+    it('returns false for non sub dir', () => {
+      expect(checkIfSubDir('/abc', '/def/ghi')).toBe(false)
+      expect(checkIfSubDir('/abc/', '/def/ghi')).toBe(false)
     })
   })
 })

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,5 +1,5 @@
 import { bold, cyan, red, green } from 'kleur/colors'
-import { resolve, dirname } from 'path'
+import { resolve, dirname, relative } from 'path'
 import {
   existsSync,
   mkdirSync,
@@ -11,6 +11,7 @@ import walk from 'walkdir'
 import { MONOREPO_TEMPLATE_PATH, TEMPLATES, TEMPLATES_PATH } from '../../config'
 import {
   betterPrompts,
+  checkIfSubDir,
   filterPathsToInclude,
   promptName,
   runCommand,
@@ -133,9 +134,11 @@ export const add: AddFunc = async (args) => {
     ).stdout,
   )
 
+  const relativePath = getRelativePath(repoRootPath)
+
   console.log(bold(cyan(`\n\nYour project \`${packageName}\` is ready 🚀\n`)))
   console.log(`- To run development mode run the following commands:`)
-  console.log(`    >`, green(`cd ${repoRootPath}`))
+  console.log(`    >`, green(`cd ${relativePath}`))
   if (structure === 'polyrepo') {
     console.log(`    >`, green(`yarn dev`))
   } else if (structure === 'monorepo') {
@@ -143,7 +146,7 @@ export const add: AddFunc = async (args) => {
   }
 
   console.log(`\n\n- To deploy the newly created field plugin to Storyblok:`)
-  console.log(`    >`, green(`cd ${repoRootPath}`))
+  console.log(`    >`, green(`cd ${relativePath}`))
   if (structure === 'polyrepo') {
     console.log(`    >`, green(`yarn deploy`))
   } else if (structure === 'monorepo') {
@@ -151,3 +154,8 @@ export const add: AddFunc = async (args) => {
   }
   return { destPath }
 }
+
+const getRelativePath = (rootPath: string) =>
+  checkIfSubDir(process.cwd(), rootPath)
+    ? relative(process.cwd(), rootPath)
+    : rootPath

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv'
 import prompts from 'prompts'
-import { resolve } from 'path'
+import { isAbsolute, relative, resolve } from 'path'
 import { existsSync, appendFileSync } from 'fs'
 import { bold, cyan } from 'kleur/colors'
 
@@ -149,4 +149,14 @@ export const initializeNewRepo = async ({ dir }: { dir: string }) => {
     shell: true,
     cwd: dir,
   })
+}
+
+export const checkIfSubDir = (parent: string, dir: string) => {
+  const relativePath = relative(parent, dir)
+
+  if (!relativePath) {
+    return false
+  }
+
+  return !relativePath.startsWith('..') && !isAbsolute(relativePath)
 }


### PR DESCRIPTION
## What?
- show relative path to use if the directory when field plugin was created is a subdirectory
## Why?
[EXT-1302](https://storyblok.atlassian.net/browse/EXT-1302)


## How to test? (optional)
1. Create a field plugin outside the current directory
2. Create a field plugin inside the current directory

[EXT-1302]: https://storyblok.atlassian.net/browse/EXT-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ