### PR TITLE
EXT-1495: check-version script to Detect new Files

### DIFF
--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -62,17 +62,12 @@ if (currentBranch.toString().trim() !== 'main') {
 }
 
 // Check if the working directory is clean
-try {
-  await $`git add .`
-  await $`git diff-index --quiet HEAD --`
-} catch (processOutput) {
-  if (processOutput.exitCode === 1) {
-    print(
-      bold(red('[Error]')),
-      'There are uncommitted changes in the working directory. Please clean them up before proceeding.',
-    )
-    exit(1)
-  }
+if ((await $`git status --porcelain`.quiet()).toString().trim() !== '') {
+  print(
+    bold(red('[Error]')),
+    'There are uncommitted changes in the working directory. Please clean them up before proceeding.',
+  )
+  exit(1)
 }
 
 // Select which package to deploy ('field-plugin' | 'cli')

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -63,6 +63,7 @@ if (currentBranch.toString().trim() !== 'main') {
 
 // Check if the working directory is clean
 try {
+  await $`git add .`
   await $`git diff-index --quiet HEAD --`
 } catch (processOutput) {
   if (processOutput.exitCode === 1) {


### PR DESCRIPTION
## What?

bump-version.mjs now checks if there are any new, uncommitted files before it proceeds.

## Why?

`git diff-index --quiet HEAD --` doesn't detect _new_ files.

## How to test? (optional)

Ansure that the are no uncmitted change, add a new file, and run

```shell
echo $?
git diff-index --quiet HEAD --
echo $?
git add .
git diff-index --quiet HEAD --
echo $?
```

The first and second echo commands will give `0`, while the last will give `1`.
