### PR TITLE
chore: run CI tasks for templates when the library code changes

### DIFF
--- a/.github/workflows/npm-publish-library.yml
+++ b/.github/workflows/npm-publish-library.yml
@@ -1,4 +1,4 @@
-name: Publish field-plugin to NPM
+name: Publish library to NPM
 
 on:
   release:
@@ -7,7 +7,7 @@ on:
 jobs:
   publish-npm:
     if: startsWith(github.event.release.name, '@storyblok/field-plugin@')
-    name: Publish field-plugin to NPM
+    name: Publish library to NPM
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/template-js.yml
+++ b/.github/workflows/template-js.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - 'packages/cli/templates/js/**'
+      - 'packages/field-plugin/**'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/template-react.yml
+++ b/.github/workflows/template-react.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - 'packages/cli/templates/react/**'
+      - 'packages/field-plugin/**'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/template-vue2.yml
+++ b/.github/workflows/template-vue2.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - 'packages/cli/templates/vue2/**'
+      - 'packages/field-plugin/**'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/template-vue3.yml
+++ b/.github/workflows/template-vue3.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - 'packages/cli/templates/vue3/**'
+      - 'packages/field-plugin/**'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What?

Currently we run CI tasks for templates only when their own code changes. However, whenever something changes on the library side, we need to run the tests compatibility with the templates.
