### PR TITLE
EXT-1338: do not initialize repo if already

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -143,12 +143,25 @@ export const filterPathsToInclude = (
   files.filter((file) => file !== 'node_modules' && file !== 'cache')
 
 export const initializeNewRepo = async ({ dir }: { dir: string }) => {
+  if (await checkIfInsideRepository({ dir })) {
+    return
+  }
+
   await runCommand('git init', { cwd: dir })
   await runCommand('git add .', { cwd: dir })
   await runCommand('git commit -m "chore: initial commit"', {
     shell: true,
     cwd: dir,
   })
+}
+
+export const checkIfInsideRepository = async ({ dir }: { dir: string }) => {
+  try {
+    await runCommand('git rev-parse --is-inside-work-tree', { cwd: dir })
+    return true
+  } catch (err) {
+    return false
+  }
 }
 
 export const checkIfSubDir = (parent: string, dir: string) => {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -147,12 +147,16 @@ export const initializeNewRepo = async ({ dir }: { dir: string }) => {
     return
   }
 
-  await runCommand('git init', { cwd: dir })
-  await runCommand('git add .', { cwd: dir })
-  await runCommand('git commit -m "chore: initial commit"', {
-    shell: true,
-    cwd: dir,
-  })
+  try {
+    await runCommand('git init', { cwd: dir })
+    await runCommand('git add .', { cwd: dir })
+    await runCommand('git commit -m "chore: initial commit"', {
+      shell: true,
+      cwd: dir,
+    })
+  } catch (err) {
+    // ignore if git commands fail
+  }
 }
 
 export const checkIfInsideRepository = async ({ dir }: { dir: string }) => {


### PR DESCRIPTION
## What?

This PR stops the CLI from running `git init` if the directory already belongs to a git repository.
