### PR TITLE
chore(common): update pull-request title checking logic

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,11 +2,19 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-# https://github.com/marketplace/actions/pull-request-title-rules
+# https://github.com/amannn/action-semantic-pull-request
 jobs:
   title-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: deepakputhraya/action-pr-title@master
+      - uses: amannn/action-semantic-pull-request@v5
         with:
-          allowed_prefixes: 'EXT-,chore:'
+          scopes: |
+            common
+            lib
+            sandbox
+            cli
+            cli-create
+            cli-add
+            cli-deploy
+          requireScope: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           scopes: |
             common

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,7 +16,5 @@ jobs:
             lib
             sandbox
             cli
-            cli-create
-            cli-add
-            cli-deploy
+            template
           requireScope: true

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -28,6 +28,11 @@ const PACKAGE_FOLDERS = [
   },
 ]
 
+const COMMIT_SCOPE = {
+  '@storyblok/field-plugin': 'lib',
+  '@storyblok/field-plugin-cli': 'cli',
+}
+
 // Check if `gh` exists
 if (!(await which('gh', { nothrow: true }))) {
   print(
@@ -165,7 +170,8 @@ await $`yarn install`
 
 // Create a pull-request
 await $`git add .`
-const commitMessage = `chore: release ${packageName}@${nextVersion}`
+const scope = COMMIT_SCOPE[packageName]
+const commitMessage = `chore(${scope}): release ${packageName}@${nextVersion}`
 await $`git commit -m ${commitMessage}`
 await $`git push -u origin ${branchName}`
 await $`gh pr create --title ${commitMessage} --web`


### PR DESCRIPTION
## What?

This PR updates pull-request title checking logic.

Now it's following the semantic rules: https://github.com/amannn/action-semantic-pull-request

## Why?

EXT-1255

It helps us better distinguish commits by type of work and package.

## Discussion

Current I've put the following scopes:

- common
- lib
- sandbox
- cli
- cli-create
- cli-add
- cli-deploy

Any update you'd like to see?

(They are used like `fix(cli-deploy): load environment variables from .env.local`)