### PR TITLE
chore: revert prettier config for templates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 node_modules/
 packages/*/dist/
-packages/cli/templates/


### PR DESCRIPTION
## What?

This PR removes templates from the `.prettierignore`, which was introduced in #152 

Since #152, when we work on the templates, the "format-on-save" didn't work at all on VSCode.

## Why?

We shouldn't exclude the source files from prettier.
