### PR TITLE
fix(template): Compile templates to CommonJS

### DIFF
--- a/packages/cli/templates/js/vite.config.js
+++ b/packages/cli/templates/js/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
+        format: 'commonjs',
         entryFileNames: `[name].js`,
         chunkFileNames: `[name].js`,
         assetFileNames: `[name].[ext]`,

--- a/packages/cli/templates/react/vite.config.ts
+++ b/packages/cli/templates/react/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
+        format: 'commonjs',
         entryFileNames: `[name].js`,
         chunkFileNames: `[name].js`,
         assetFileNames: `[name].[ext]`,

--- a/packages/cli/templates/vue2/vite.config.ts
+++ b/packages/cli/templates/vue2/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     // minify: false,
     rollupOptions: {
       output: {
+        format: 'commonjs',
         entryFileNames: `[name].js`,
         chunkFileNames: `[name].js`,
         assetFileNames: `[name].[ext]`,

--- a/packages/cli/templates/vue3/vite.config.ts
+++ b/packages/cli/templates/vue3/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
+        format: 'commonjs',
         entryFileNames: `[name].js`,
         chunkFileNames: `[name].js`,
         assetFileNames: `[name].[ext]`,


### PR DESCRIPTION
## What?

For all templates, configuring rollup to output in CommonJs. 

## Why?

EXT-1501

The document that Storyblok serves for field plugins wraps the code within a script element. This element does not have the attribute `type` set to `"module"`. Thus, if one provides code that uses JavaScript modules, this will fail with a syntax error. 

However, during development, Vite utilizes JavaScript modules and serves the code from a script element with `type="module"`. This descrepency could make the developer think that their code is functional, while after deploying to production, it would fail to execute.

