### PR TITLE
fix(sandbox): Initial Content Changed to an Empty String (`""`)

### DIFF
--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -45,6 +45,7 @@ const uid = () => Math.random().toString(32).slice(2)
 
 const wrapperHost = 'localhost:7070'
 const defaultUrl = 'http://localhost:8080'
+const initialContent = ''
 const initialHeight = 300
 const initialWidth = 300
 
@@ -112,7 +113,7 @@ export const FieldPluginContainer: FunctionComponent = () => {
     field_type: 'preview',
     options: [],
   })
-  const [value, setValue] = useState<unknown>(undefined)
+  const [value, setValue] = useState<unknown>(initialContent)
 
   const handleRefreshIframe = () => {
     setIframeUid(uid)


### PR DESCRIPTION
## What?

Changed the initial/default content (`data.value`) to be an empty string.

## Why?

JIRA: EXT-1500

This is the default behaviour of the Visual Editor.
