### PR TITLE
chore(template): add .prettierrc to templates

### DIFF
--- a/packages/cli/templates/js/.prettierrc
+++ b/packages/cli/templates/js/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "singleAttributePerLine": true
+}

--- a/packages/cli/templates/monorepo/.prettierrc
+++ b/packages/cli/templates/monorepo/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "singleAttributePerLine": true
+}

--- a/packages/cli/templates/react/.prettierrc
+++ b/packages/cli/templates/react/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "singleAttributePerLine": true
+}

--- a/packages/cli/templates/vue2/.prettierrc
+++ b/packages/cli/templates/vue2/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "singleAttributePerLine": true
+}

--- a/packages/cli/templates/vue3/.prettierrc
+++ b/packages/cli/templates/vue3/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "singleAttributePerLine": true
+}


### PR DESCRIPTION
## What?

This PR adds `.prettierrc` to all the templates.

## Why?

Without this file, once user creates their own repository, their IDE might unnecessarily format code differently if they have different default config than our `.prettierrc` at the root of this repository.