### PR TITLE
feat(lib)!: `setPluginReady` Removed from `FieldPluginActions`

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
@@ -3,7 +3,6 @@ import { Asset } from '../messaging'
 export type SetHeight = (heightPx: number) => void
 export type SetValue = (value: unknown) => void
 export type SetModalOpen = (isModal: boolean) => void
-export type SetPluginReady = () => void
 export type RequestContext = () => void
 export type SelectAsset = () => Promise<Asset>
 
@@ -11,7 +10,6 @@ export type FieldPluginActions = {
   setHeight: SetHeight
   setValue: SetValue
   setModalOpen: SetModalOpen
-  setPluginReady: SetPluginReady
   requestContext: RequestContext
   selectAsset: SelectAsset
 }

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
@@ -149,20 +149,6 @@ describe('createPluginActions', () => {
       )
     })
   })
-  describe('setPluginReady()', () => {
-    it('send a message to the container to receive the initial state', () => {
-      const { uid, postToContainer, onUpdateState } = mock()
-      const {
-        actions: { setPluginReady },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
-      setPluginReady()
-      expect(postToContainer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          event: 'loaded',
-        } satisfies Partial<PluginLoadedMessage>),
-      )
-    })
-  })
   describe('requestContext()', () => {
     it('send a message to the container to request the story', () => {
       const { uid, postToContainer, onUpdateState } = mock()

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -12,7 +12,6 @@ import {
   OnContextRequestMessage,
   OnStateChangeMessage,
   OnUnknownPluginMessage,
-  pluginLoadedMessage,
   valueChangeMessage,
 } from '../../messaging'
 import { FieldPluginActions } from '../FieldPluginActions'
@@ -96,8 +95,6 @@ export const createPluginActions: CreatePluginActions = (
     onUnknownMessage,
   }
 
-  // Receive the current value
-  const setPluginReady = () => postToContainer(pluginLoadedMessage(uid))
   return {
     actions: {
       setHeight: (height) => {
@@ -130,7 +127,6 @@ export const createPluginActions: CreatePluginActions = (
           postToContainer(assetModalChangeMessage(uid))
         })
       },
-      setPluginReady,
       requestContext: () => postToContainer(getContextMessage(uid)),
     },
     messageCallbacks,


### PR DESCRIPTION
## What?

Removes `setPluginReady` from `FieldPluginActions`.

## Why?

`setPluginReady` is only used internally in `createFieldPlugin` to request the initial state from the Visual Editor (container)
