### PR TITLE
feat(lib)!: `setHeight` removed from `FieldPluginActions`. `height` removed from `FieldPluginData`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Storyblok provides the following starter projects:
 - Vue 2 (Options API)
 - Vanilla JavaScript
 
-[//]: # (- Solid)
+[//]: # '- Solid'
 
-## Integrating @storyblok/field-plugin 
+## Integrating @storyblok/field-plugin
 
 To integrate `@storyblok/field-plugin` into a frontend framework, bootstrap your application with the `--template js` flag.
 
@@ -34,7 +34,7 @@ rootElement.id = 'app'
 document.body.appendChild(rootElement)
 ```
 
-This adds a new node to the `body`. Mount your application to this node, and in the  root component, run  `createFieldPlugin()` as an effect. This will make your application start listening to events from Storyblok's Visual Editor.
+This adds a new node to the `body`. Mount your application to this node, and in the root component, run `createFieldPlugin()` as an effect. This will make your application start listening to events from Storyblok's Visual Editor.
 
 Pass a callback function as an argument to `createFieldPlugin()`. This function will be called whenever the state of the
 field plugin changes; such as when the user changes the value in the visual editor, opens the modal, selects an
@@ -63,7 +63,6 @@ createFieldPlugin((response) => {
   buttonEl.textContent = `Increment: ${data.value ?? 0}`
   buttonEl.onclick = () => actions.setValue((data.value ?? 0) + 1)
 })
-
 ```
 
 ### React
@@ -71,13 +70,13 @@ createFieldPlugin((response) => {
 With React, create a hook:
 
 ```typescript
-import {createFieldPlugin, FieldPluginResponse} from '@storyblok/field-plugin'
-import {useEffect, useState} from 'react'
+import { createFieldPlugin, FieldPluginResponse } from '@storyblok/field-plugin'
+import { useEffect, useState } from 'react'
 
 type UseFieldPlugin = () => FieldPluginResponse
 
 export const useFieldPlugin: UseFieldPlugin = () => {
-  const [state, setState] = useState<FieldPluginResponse>({type: 'loading'})
+  const [state, setState] = useState<FieldPluginResponse>({ type: 'loading' })
 
   useEffect(() => {
     return createFieldPlugin(setState)
@@ -91,7 +90,7 @@ And render your component as such:
 
 ```tsx
 export const App = () => {
-  const {type, data, actions} = useFieldPlugin()
+  const { type, data, actions } = useFieldPlugin()
 
   if (type !== 'loaded') {
     return <></>
@@ -102,52 +101,30 @@ export const App = () => {
   const label =
     typeof data.value === 'undefined' ? 'undefined' : JSON.stringify(data.value)
 
-  return (
-    <button onClick={handleClickIncrement}>
-      {label}
-    </button>
-  )
+  return <button onClick={handleClickIncrement}>{label}</button>
 }
 ```
 
-[//]: # (### Vue 3)
-
-[//]: # ()
-[//]: # (Coming soon...)
-
-[//]: # (With the composition api, create a hook:)
-
-[//]: # ()
-
-[//]: # (```markdown)
-
-[//]: # (TODO:)
-
-[//]: # (Something like)
-
-[//]: # (1. create a reactive value)
-
-[//]: # (2. call useFieldPlugin)
-
-[//]: # (3. in useFieldPlugin's argument, update the state)
-
-[//]: # (4. Note that we cannot send reactive objects via `Window.postMessage&#40;&#41;`, so we have to proxy all calls to setValue in a function that wraps the value in `JSON.parse&#40;JSON.stringify&#40;value&#41;&#41;`)
-
-[//]: # (5. return the reactive value from the hook)
-
-[//]: # (```)
-
-[//]: # ()
-
-[//]: # (With the options api, create a mixin:)
-
-[//]: # ()
-
-[//]: # (```vue)
-
-[//]: # (TODO)
-
-[//]: # (```)
+[//]: # '### Vue 3'
+[//]: #
+[//]: # 'Coming soon...'
+[//]: # 'With the composition api, create a hook:'
+[//]: #
+[//]: # '```markdown'
+[//]: # 'TODO:'
+[//]: # 'Something like'
+[//]: # '1. create a reactive value'
+[//]: # '2. call useFieldPlugin'
+[//]: # "3. in useFieldPlugin's argument, update the state"
+[//]: # '4. Note that we cannot send reactive objects via `Window.postMessage()`, so we have to proxy all calls to setValue in a function that wraps the value in `JSON.parse(JSON.stringify(value))`'
+[//]: # '5. return the reactive value from the hook'
+[//]: # '```'
+[//]: #
+[//]: # 'With the options api, create a mixin:'
+[//]: #
+[//]: # '```vue'
+[//]: # 'TODO'
+[//]: # '```'
 
 ## API Reference
 
@@ -170,7 +147,7 @@ Return Value: `() => void`: A function that removes the event listeners added by
 Properties:
 
 | Key       | Defined when `FieldPluginResponse.type` is | Description                                                                                                                                                                                                                  |
-|-----------|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `type`    |                                            | A string that indicates which overall state your field plugin is in. It can assume three values `loading`, `error`, and `loaded`.                                                                                            |
 | `error`   | `"error"`                                  | If `FieldPluginResponse.type` is `error`, the `error` property will contain an `Error` object instance. Otherwise, it is `undefined`.                                                                                        |
 | `data`    | `"loaded"`                                 | When `FieldPluginResponse.type` is `loaded`, this property will contain the state of the application that the Visual Editor has shared with the field plugin. Otherwise, it is `undefined`.                                  |
@@ -181,7 +158,7 @@ Properties:
 `FieldPluginResponse.type` can assume three different values:
 
 | Value       | Description                                                                                                                                                                         |
-|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `"loading"` | When the state is initially loaded and has not yet establish communication with the Visual Editor.                                                                                  |
 | `"error"`   | The plugin failed to load. This can happen, for example, if the field plugin URL is opened outside the Visual Editor. This is typically not a scenario that needs to be considered. |
 | `"loaded"`  | The plugin successfully loaded and is ready-to-use.                                                                                                                                 |
@@ -190,29 +167,28 @@ Properties:
 
 `FieldPluginResponse.data` has the following properties:
 
-| Key           | Description                                                                                                                                                                                |
-|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `value`       | The value of the field plugin that is part of the content.                                                                                                                                 |
-| `options`     | A dictionary/record of `string` key-value pairs, containing the options that were set up for this field plugin in the block schema.                                                        |
-| `isModalOpen` | A boolean value that indicates whether the field plugin is embedded in a modal window.                                                                                                     |
-| `language`    | The current language. Can be an empty string (`""`).                                                                                                                                       |
-| `spaceId`     | The ID of the space.                                                                                                                                                                       |
-| `story`       | The story how it was when the plugin was _initially_ loaded. To update this after the initial load,                                   please refer to `response.actions.requestContext()`. |
-| `storyId`     | The ID of the story.                                                                                                                                                                       |
-| `blockUid`    | The UID of the block that the field plugin is part of.                                                                                                                                     |
-| `token`       | A draft access token to  the [Content Delivery API](https://www.storyblok.com/docs/api/content-delivery/v2#topics/authentication).                                                         |
-| `uid`         | The UID of the field plugin.                                                                                                                                                               |
-| `height`      | the height of the window.                                                                                                                                                                  |
+| Key           | Description                                                                                                                                              |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`       | The value of the field plugin that is part of the content.                                                                                               |
+| `options`     | A dictionary/record of `string` key-value pairs, containing the options that were set up for this field plugin in the block schema.                      |
+| `isModalOpen` | A boolean value that indicates whether the field plugin is embedded in a modal window.                                                                   |
+| `language`    | The current language. Can be an empty string (`""`).                                                                                                     |
+| `spaceId`     | The ID of the space.                                                                                                                                     |
+| `story`       | The story how it was when the plugin was _initially_ loaded. To update this after the initial load, please refer to `response.actions.requestContext()`. |
+| `storyId`     | The ID of the story.                                                                                                                                     |
+| `blockUid`    | The UID of the block that the field plugin is part of.                                                                                                   |
+| `token`       | A draft access token to the [Content Delivery API](https://www.storyblok.com/docs/api/content-delivery/v2#topics/authentication).                        |
+| `uid`         | The UID of the field plugin.                                                                                                                             |
 
 #### FieldPluginResponse.actions
 
 `FieldPluginResponse.actions` has the following properties:
 
-| Key                | Description                                                                                                                                                                                           |
-|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `setValue`         | Updates the value of the field plugin. For example, `setValue(3.14159)`                                                                                                                               |
-| `setModalOpen`     | Opens/Closes the modal window. For example, `setModalOpen(true)`.                                                                                                                                     |
-| `selectAsset`      | Opens the asset selector. Returns a promise that gets resolved when the user selects an asset. For example, `selectAsset().then((filename) => console.log(filename))`                    |
+| Key                | Description                                                                                                                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setValue`         | Updates the value of the field plugin. For example, `setValue(3.14159)`                                                                                                                                  |
+| `setModalOpen`     | Opens/Closes the modal window. For example, `setModalOpen(true)`.                                                                                                                                        |
+| `selectAsset`      | Opens the asset selector. Returns a promise that gets resolved when the user selects an asset. For example, `selectAsset().then((filename) => console.log(filename))`                                    |
 | `requestContext()` | Updates the `request.data.story` property to the version of the story that is currently opened in the Visual Editor. That is, the unsaved version of the story that exists in the user's browser memory. |
 
 ## Caveats

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Storyblok provides the following starter projects:
 - Vue 2 (Options API)
 - Vanilla JavaScript
 
-[//]: # (- Solid)
+[//]: # '- Solid'
 
-## Integrating @storyblok/field-plugin 
+## Integrating @storyblok/field-plugin
 
 To integrate `@storyblok/field-plugin` into a frontend framework, bootstrap your application with the `--template js` flag.
 
@@ -34,7 +34,7 @@ rootElement.id = 'app'
 document.body.appendChild(rootElement)
 ```
 
-This adds a new node to the `body`. Mount your application to this node, and in the  root component, run  `createFieldPlugin()` as an effect. This will make your application start listening to events from Storyblok's Visual Editor.
+This adds a new node to the `body`. Mount your application to this node, and in the root component, run `createFieldPlugin()` as an effect. This will make your application start listening to events from Storyblok's Visual Editor.
 
 Pass a callback function as an argument to `createFieldPlugin()`. This function will be called whenever the state of the
 field plugin changes; such as when the user changes the value in the visual editor, opens the modal, selects an
@@ -63,7 +63,6 @@ createFieldPlugin((response) => {
   buttonEl.textContent = `Increment: ${data.content ?? 0}`
   buttonEl.onclick = () => actions.setContent((data.content ?? 0) + 1)
 })
-
 ```
 
 ### React
@@ -71,13 +70,13 @@ createFieldPlugin((response) => {
 With React, create a hook:
 
 ```typescript
-import {createFieldPlugin, FieldPluginResponse} from '@storyblok/field-plugin'
-import {useEffect, useState} from 'react'
+import { createFieldPlugin, FieldPluginResponse } from '@storyblok/field-plugin'
+import { useEffect, useState } from 'react'
 
 type UseFieldPlugin = () => FieldPluginResponse
 
 export const useFieldPlugin: UseFieldPlugin = () => {
-  const [state, setState] = useState<FieldPluginResponse>({type: 'loading'})
+  const [state, setState] = useState<FieldPluginResponse>({ type: 'loading' })
 
   useEffect(() => {
     return createFieldPlugin(setState)
@@ -91,63 +90,45 @@ And render your component as such:
 
 ```tsx
 export const App = () => {
-  const {type, data, actions} = useFieldPlugin()
+  const { type, data, actions } = useFieldPlugin()
 
   if (type !== 'loaded') {
     return <></>
   }
 
   const handleClickIncrement = () =>
-    actions.setContent((typeof data.content === 'number' ? data.content : 0) + 1)
+    actions.setContent(
+      (typeof data.content === 'number' ? data.content : 0) + 1,
+    )
   const label =
-    typeof data.content === 'undefined' ? 'undefined' : JSON.stringify(data.content)
+    typeof data.content === 'undefined'
+      ? 'undefined'
+      : JSON.stringify(data.content)
 
-  return (
-    <button onClick={handleClickIncrement}>
-      {label}
-    </button>
-  )
+  return <button onClick={handleClickIncrement}>{label}</button>
 }
 ```
 
-[//]: # (### Vue 3)
-
-[//]: # ()
-[//]: # (Coming soon...)
-
-[//]: # (With the composition api, create a hook:)
-
-[//]: # ()
-
-[//]: # (```markdown)
-
-[//]: # (TODO:)
-
-[//]: # (Something like)
-
-[//]: # (1. create a reactive value)
-
-[//]: # (2. call useFieldPlugin)
-
-[//]: # (3. in useFieldPlugin's argument, update the state)
-
-[//]: # (4. Note that we cannot send reactive objects via `Window.postMessage&#40;&#41;`, so we have to proxy all calls to setContent in a function that wraps the value in `JSON.parse&#40;JSON.stringify&#40;value&#41;&#41;`)
-
-[//]: # (5. return the reactive value from the hook)
-
-[//]: # (```)
-
-[//]: # ()
-
-[//]: # (With the options api, create a mixin:)
-
-[//]: # ()
-
-[//]: # (```vue)
-
-[//]: # (TODO)
-
-[//]: # (```)
+[//]: # '### Vue 3'
+[//]: #
+[//]: # 'Coming soon...'
+[//]: # 'With the composition api, create a hook:'
+[//]: #
+[//]: # '```markdown'
+[//]: # 'TODO:'
+[//]: # 'Something like'
+[//]: # '1. create a reactive value'
+[//]: # '2. call useFieldPlugin'
+[//]: # "3. in useFieldPlugin's argument, update the state"
+[//]: # '4. Note that we cannot send reactive objects via `Window.postMessage()`, so we have to proxy all calls to setContent in a function that wraps the value in `JSON.parse(JSON.stringify(value))`'
+[//]: # '5. return the reactive value from the hook'
+[//]: # '```'
+[//]: #
+[//]: # 'With the options api, create a mixin:'
+[//]: #
+[//]: # '```vue'
+[//]: # 'TODO'
+[//]: # '```'
 
 ## API Reference
 
@@ -170,7 +151,7 @@ Return Value: `() => void`: A function that removes the event listeners added by
 Properties:
 
 | Key       | Defined when `FieldPluginResponse.type` is | Description                                                                                                                                                                                                                  |
-|-----------|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `type`    |                                            | A string that indicates which overall state your field plugin is in. It can assume three values `loading`, `error`, and `loaded`.                                                                                            |
 | `error`   | `"error"`                                  | If `FieldPluginResponse.type` is `error`, the `error` property will contain an `Error` object instance. Otherwise, it is `undefined`.                                                                                        |
 | `data`    | `"loaded"`                                 | When `FieldPluginResponse.type` is `loaded`, this property will contain the state of the application that the Visual Editor has shared with the field plugin. Otherwise, it is `undefined`.                                  |
@@ -181,7 +162,7 @@ Properties:
 `FieldPluginResponse.type` can assume three different values:
 
 | Value       | Description                                                                                                                                                                         |
-|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `"loading"` | When the state is initially loaded and has not yet establish communication with the Visual Editor.                                                                                  |
 | `"error"`   | The plugin failed to load. This can happen, for example, if the field plugin URL is opened outside the Visual Editor. This is typically not a scenario that needs to be considered. |
 | `"loaded"`  | The plugin successfully loaded and is ready-to-use.                                                                                                                                 |
@@ -190,29 +171,28 @@ Properties:
 
 `FieldPluginResponse.data` has the following properties:
 
-| Key           | Description                                                                                                                                                                                |
-|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `content`       | The content of the field plugin that is part of the content.                                                                                                                                 |
-| `options`     | A dictionary/record of `string` key-value pairs, containing the options that were set up for this field plugin in the block schema.                                                        |
-| `isModalOpen` | A boolean value that indicates whether the field plugin is embedded in a modal window.                                                                                                     |
-| `language`    | The current language. Can be an empty string (`""`).                                                                                                                                       |
-| `spaceId`     | The ID of the space.                                                                                                                                                                       |
-| `story`       | The story how it was when the plugin was _initially_ loaded. To update this after the initial load,                                   please refer to `response.actions.requestContext()`. |
-| `storyId`     | The ID of the story.                                                                                                                                                                       |
-| `blockUid`    | The UID of the block that the field plugin is part of.                                                                                                                                     |
-| `token`       | A draft access token to  the [Content Delivery API](https://www.storyblok.com/docs/api/content-delivery/v2#topics/authentication).                                                         |
-| `uid`         | The UID of the field plugin.                                                                                                                                                               |
-| `height`      | the height of the window.                                                                                                                                                                  |
+| Key           | Description                                                                                                                                              |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`     | The content of the field plugin that is part of the content.                                                                                             |
+| `options`     | A dictionary/record of `string` key-value pairs, containing the options that were set up for this field plugin in the block schema.                      |
+| `isModalOpen` | A boolean value that indicates whether the field plugin is embedded in a modal window.                                                                   |
+| `language`    | The current language. Can be an empty string (`""`).                                                                                                     |
+| `spaceId`     | The ID of the space.                                                                                                                                     |
+| `story`       | The story how it was when the plugin was _initially_ loaded. To update this after the initial load, please refer to `response.actions.requestContext()`. |
+| `storyId`     | The ID of the story.                                                                                                                                     |
+| `blockUid`    | The UID of the block that the field plugin is part of.                                                                                                   |
+| `token`       | A draft access token to the [Content Delivery API](https://www.storyblok.com/docs/api/content-delivery/v2#topics/authentication).                        |
+| `uid`         | The UID of the field plugin.                                                                                                                             |
 
 #### FieldPluginResponse.actions
 
 `FieldPluginResponse.actions` has the following properties:
 
-| Key                | Description                                                                                                                                                                                           |
-|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `setContent`         | Updates the content of the field plugin. For example, `setContent(3.14159)`                                                                                                                               |
-| `setModalOpen`     | Opens/Closes the modal window. For example, `setModalOpen(true)`.                                                                                                                                     |
-| `selectAsset`      | Opens the asset selector. Returns a promise that gets resolved when the user selects an asset. For example, `selectAsset().then((filename) => console.log(filename))`                    |
+| Key                | Description                                                                                                                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setContent`       | Updates the content of the field plugin. For example, `setContent(3.14159)`                                                                                                                              |
+| `setModalOpen`     | Opens/Closes the modal window. For example, `setModalOpen(true)`.                                                                                                                                        |
+| `selectAsset`      | Opens the asset selector. Returns a promise that gets resolved when the user selects an asset. For example, `selectAsset().then((filename) => console.log(filename))`                                    |
 | `requestContext()` | Updates the `request.data.story` property to the version of the story that is currently opened in the Visual Editor. That is, the unsaved version of the story that exists in the user's browser memory. |
 
 ## Caveats

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prompts": "2.4.2",
     "semver": "7.3.8",
     "ts-jest": "29.0.1",
-    "typescript": "4.9.4",
+    "typescript": "^5.0.4",
     "vite": "3.2.3",
     "vite-plugin-dts": "1.7.1",
     "zx": "7.2.1"

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "11.10.5",
     "@fontsource/roboto": "4.5.8",
     "@mui/material": "5.11.0",
-    "@storyblok/field-plugin": "0.0.1-alpha.2",
+    "@storyblok/field-plugin": "0.0.1-alpha.3",
     "@storyblok/mui": "0.0.22",
     "highlight.js": "11.7.0",
     "react": "18.2.0",

--- a/packages/container/src/components/ContentView.tsx
+++ b/packages/container/src/components/ContentView.tsx
@@ -3,9 +3,9 @@ import { Button, ButtonGroup, Tooltip, Typography } from '@mui/material'
 import { DeleteIcon } from '@storyblok/mui'
 import { ObjectView } from './ObjectView'
 
-export const ValueView: FunctionComponent<{
-  value: unknown
-  setValue: (value: unknown) => void
+export const ContentView: FunctionComponent<{
+  content: unknown
+  setContent: (content: unknown) => void
 }> = (props) => (
   <ObjectView
     title={
@@ -13,8 +13,8 @@ export const ValueView: FunctionComponent<{
         FieldPluginResponse.data.content
       </Typography>
     }
-    output={props.value}
-    actions={<Actions onRemove={() => props.setValue(undefined)} />}
+    output={props.content}
+    actions={<Actions onRemove={() => props.setContent(undefined)} />}
   />
 )
 

--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -9,6 +9,7 @@ import {
 import {
   AssetSelectedMessage,
   ContextRequestMessage,
+  FieldPluginData,
   FieldPluginSchema,
   originFromPluginParams,
   PluginUrlParams,
@@ -286,12 +287,13 @@ export const FieldPluginContainer: FunctionComponent = () => {
                   FieldPluginResponse.data
                 </Typography>
               }
-              output={{
-                value,
-                height,
-                isModal,
-                options: recordFromFieldPluginOptions(schema.options),
-              }}
+              output={
+                {
+                  value,
+                  isModal,
+                  options: recordFromFieldPluginOptions(schema.options),
+                } satisfies FieldPluginData
+              }
             />
           </AccordionDetails>
         </Accordion>

--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -33,7 +33,7 @@ import { SchemaEditor } from './SchemaEditor'
 import { FieldTypePreview } from './FieldTypePreview'
 import { createContainerMessageListener } from '../dom/createContainerMessageListener'
 import { useDebounce } from 'use-debounce'
-import { ValueView } from './ValueView'
+import { ContentView } from './ContentView'
 import { StringParam, useQueryParam, withDefault } from 'use-query-params'
 import { ObjectView } from './ObjectView'
 import { UrlView } from './UrlView'
@@ -104,13 +104,13 @@ export const FieldPluginContainer: FunctionComponent = () => {
 
   // State
   // TODO replace with useReducer
-  const [isModal, setModal] = useState(false)
+  const [isModalOpen, setModalOpen] = useState(false)
   const [height, setHeight] = useState(initialHeight)
   const [schema, setSchema] = useState<FieldPluginSchema>({
     field_type: 'preview',
     options: [],
   })
-  const [value, setValue] = useState<unknown>(initialContent)
+  const [content, setContent] = useState<unknown>(initialContent)
 
   const handleRefreshIframe = () => {
     setIframeUid(uid)
@@ -118,7 +118,7 @@ export const FieldPluginContainer: FunctionComponent = () => {
 
   const loadedData = useMemo<StateChangedMessage>(
     () => ({
-      model: value,
+      model: content,
       schema: schema,
       action: 'loaded',
       uid: pluginParams.uid,
@@ -129,7 +129,7 @@ export const FieldPluginContainer: FunctionComponent = () => {
       storyId: undefined,
       token: null,
     }),
-    [value, schema, story],
+    [content, schema, story],
   )
 
   const postToPlugin = useCallback(
@@ -201,10 +201,10 @@ export const FieldPluginContainer: FunctionComponent = () => {
     () =>
       createContainerMessageListener(
         {
-          setValue,
+          setContent,
           setPluginReady: onLoaded,
           setHeight,
-          setModalOpen: setModal,
+          setModalOpen: setModalOpen,
           requestContext: onContextRequested,
           selectAsset: onAssetSelected,
         },
@@ -216,9 +216,9 @@ export const FieldPluginContainer: FunctionComponent = () => {
       ),
     [
       onLoaded,
-      setValue,
+      setContent,
       setHeight,
-      setModal,
+      setModalOpen,
       onAssetSelected,
       onContextRequested,
       fieldPluginURL,
@@ -231,7 +231,7 @@ export const FieldPluginContainer: FunctionComponent = () => {
         src={iframeSrc}
         height={`${height}px`}
         initialWidth={`${initialWidth}px`}
-        isModal={isModal}
+        isModal={isModalOpen}
         ref={fieldTypeIframe}
         uid={iframeUid}
         sx={{ my: 15 }}
@@ -264,12 +264,12 @@ export const FieldPluginContainer: FunctionComponent = () => {
             expandIcon={<ChevronDownIcon />}
             sx={{ p: 0 }}
           >
-            <Typography variant="h3">Value</Typography>
+            <Typography variant="h3">Content</Typography>
           </AccordionSummary>
           <AccordionDetails sx={{ position: 'relative' }}>
-            <ValueView
-              value={value}
-              setValue={setValue}
+            <ContentView
+              content={content}
+              setContent={setContent}
             />
           </AccordionDetails>
         </Accordion>
@@ -289,10 +289,10 @@ export const FieldPluginContainer: FunctionComponent = () => {
               }
               output={
                 {
-                  value,
-                  isModal,
+                  content,
+                  isModalOpen,
                   options: recordFromFieldPluginOptions(schema.options),
-                } satisfies FieldPluginData
+                } satisfies Partial<FieldPluginData>
               }
             />
           </AccordionDetails>

--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -220,8 +220,8 @@ const useSandbox = (
 
   return [
     {
-      value,
-      isModal,
+      content,
+      isModalOpen,
       height,
       schema,
       url,
@@ -230,7 +230,7 @@ const useSandbox = (
       iframeUid,
     },
     {
-      setValue,
+      setContent,
       setSchema,
       setUrl,
       refreshIframe,
@@ -242,8 +242,8 @@ export const FieldPluginContainer: FunctionComponent = () => {
   const { error } = useNotifications()
   const [
     {
-      value,
-      isModal,
+      content,
+      isModalOpen,
       height,
       schema,
       url,
@@ -251,7 +251,7 @@ export const FieldPluginContainer: FunctionComponent = () => {
       iframeSrc,
       iframeUid,
     },
-    { setValue, setSchema, setUrl, refreshIframe },
+    { setContent, setSchema, setUrl, refreshIframe },
   ] = useSandbox(error)
 
   return (

--- a/packages/container/src/dom/createContainerMessageListener.ts
+++ b/packages/container/src/dom/createContainerMessageListener.ts
@@ -7,7 +7,6 @@ import {
   isAssetModalChangeMessage,
   RequestContext,
   SetModalOpen,
-  SetPluginReady,
   SetContent,
   isGetContextMessage,
 } from '@storyblok/field-plugin'
@@ -16,7 +15,7 @@ type ContainerActions = {
   setHeight: (height: number) => void
   setContent: SetContent
   setModalOpen: SetModalOpen
-  setPluginReady: SetPluginReady
+  setPluginReady: () => void
   requestContext: RequestContext
   selectAsset: (field: string) => void
 }

--- a/packages/container/src/dom/createContainerMessageListener.ts
+++ b/packages/container/src/dom/createContainerMessageListener.ts
@@ -6,16 +6,15 @@ import {
   isValueChangeMessage,
   isAssetModalChangeMessage,
   RequestContext,
-  SetHeight,
   SetModalOpen,
   SetPluginReady,
-  SetValue,
+  SetContent,
   isGetContextMessage,
 } from '@storyblok/field-plugin'
 
 type ContainerActions = {
-  setHeight: SetHeight
-  setValue: SetValue
+  setHeight: (height: number) => void
+  setContent: SetContent
   setModalOpen: SetModalOpen
   setPluginReady: SetPluginReady
   requestContext: RequestContext
@@ -48,7 +47,7 @@ export const createContainerMessageListener: CreateContainerListener = (
     }
 
     if (isValueChangeMessage(message)) {
-      eventHandlers.setValue(message.model)
+      eventHandlers.setContent(message.model)
     } else if (isPluginLoadedMessage(message)) {
       eventHandlers.setPluginReady()
     } else if (isModalChangeMessage(message)) {

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
@@ -1,6 +1,5 @@
 import { Asset } from '../messaging'
 
-export type SetHeight = (heightPx: number) => void
 export type SetValue = (value: unknown) => void
 export type SetModalOpen = (isModal: boolean) => void
 export type SetPluginReady = () => void
@@ -8,7 +7,6 @@ export type RequestContext = () => void
 export type SelectAsset = () => Promise<Asset>
 
 export type FieldPluginActions = {
-  setHeight: SetHeight
   setValue: SetValue
   setModalOpen: SetModalOpen
   setPluginReady: SetPluginReady

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
@@ -4,7 +4,6 @@
 import { StoryData } from '../messaging'
 
 export type FieldPluginData = {
-  height: number
   isModalOpen: boolean
   value: unknown
   options: Record<string, string>

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
@@ -120,35 +120,6 @@ describe('createPluginActions', () => {
       )
     })
   })
-  describe('height state change', () => {
-    it('updates the height state when setHeight is called', () => {
-      const { uid, postToContainer, onUpdateState } = mock()
-      const {
-        actions: { setHeight },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
-      const height = 2403984
-      setHeight(height)
-      expect(onUpdateState).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          height,
-        } satisfies Partial<FieldPluginData>),
-      )
-    })
-    it('send a message to the container with the expected value', () => {
-      const { uid, postToContainer, onUpdateState } = mock()
-      const {
-        actions: { setHeight },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
-      const height = 289437
-      setHeight(height)
-      expect(postToContainer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          event: 'heightChange',
-          height,
-        } satisfies Partial<HeightChangeMessage>),
-      )
-    })
-  })
   describe('setPluginReady()', () => {
     it('send a message to the container to receive the initial state', () => {
       const { uid, postToContainer, onUpdateState } = mock()

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -6,7 +6,6 @@ import {
   assetFromAssetSelectedMessage,
   assetModalChangeMessage,
   getContextMessage,
-  heightChangeMessage,
   modalChangeMessage,
   OnAssetSelectMessage,
   OnContextRequestMessage,
@@ -23,7 +22,6 @@ import {
 
 // TODO get rid of this default state
 export const defaultState: FieldPluginData = {
-  height: 0,
   isModalOpen: false,
   value: undefined,
   options: {},
@@ -100,14 +98,6 @@ export const createPluginActions: CreatePluginActions = (
   const setPluginReady = () => postToContainer(pluginLoadedMessage(uid))
   return {
     actions: {
-      setHeight: (height) => {
-        postToContainer(heightChangeMessage(uid, height))
-        state = {
-          ...state,
-          height,
-        }
-        onUpdateState(state)
-      },
       setValue: (value) => {
         postToContainer(valueChangeMessage(uid, value))
         state = {

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
@@ -7,7 +7,7 @@ import {
 
 export const partialPluginStateFromStateChangeMessage = (
   message: StateChangedMessage,
-): Omit<FieldPluginData, 'height' | 'isModalOpen'> => ({
+): Omit<FieldPluginData, 'isModalOpen'> => ({
   spaceId: message.spaceId ?? undefined,
   story: message.story ?? undefined,
   storyId: message.storyId ?? undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4633,7 +4633,7 @@ __metadata:
     prompts: 2.4.2
     semver: 7.3.8
     ts-jest: 29.0.1
-    typescript: 4.9.4
+    typescript: ^5.0.4
     vite: 3.2.3
     vite-plugin-dts: 1.7.1
     zx: 7.2.1
@@ -8250,7 +8250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:*":
+"typescript@npm:*, typescript@npm:^5.0.4":
   version: 5.0.4
   resolution: "typescript@npm:5.0.4"
   bin:
@@ -8267,16 +8267,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: e7bfcc39cd4571a63a54e5ea21f16b8445268b9900bf55aee0e02ad981be576acc140eba24f1af5e3c1457767c96cea6d12861768fb386cf3ffb34013718631a
-  languageName: node
-  linkType: hard
-
-"typescript@npm:4.9.4":
-  version: 4.9.4
-  resolution: "typescript@npm:4.9.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: e782fb9e0031cb258a80000f6c13530288c6d63f1177ed43f770533fdc15740d271554cdae86701c1dd2c83b082cea808b07e97fd68b38a172a83dbf9e0d0ef9
   languageName: node
   linkType: hard
 
@@ -8300,7 +8290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@*#~builtin<compat/typescript>":
+"typescript@patch:typescript@*#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
   resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=701156"
   bin:
@@ -8317,16 +8307,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 1cb434fbc637d347be90e3a0c6cd05e33c38f941713c8786d3031faf1842c2c148ba91d2fac01e7276b0ae3249b8633f1660e32686cc7a8c6a8fd5361dc52c66
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@4.9.4#~builtin<compat/typescript>":
-  version: 4.9.4
-  resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=701156"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 37f6e2c3c5e2aa5934b85b0fddbf32eeac8b1bacf3a5b51d01946936d03f5377fe86255d4e5a4ae628fd0cd553386355ad362c57f13b4635064400f3e8e05b9d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,13 +1597,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storyblok/field-plugin@npm:0.0.1-alpha.2":
-  version: 0.0.1-alpha.2
-  resolution: "@storyblok/field-plugin@npm:0.0.1-alpha.2"
-  checksum: 70dae320a562b34524c8f377c2bfa892728bcf89f9f58679626bf3afa47b781e715988c0eaa4b82bc4376f58012036a3e81dd69b8fb7433851e0f346bceebee2
-  languageName: node
-  linkType: hard
-
 "@storyblok/mui@npm:0.0.19-alpha":
   version: 0.0.19-alpha
   resolution: "@storyblok/mui@npm:0.0.19-alpha"
@@ -3247,7 +3240,7 @@ __metadata:
     "@emotion/styled": 11.10.5
     "@fontsource/roboto": 4.5.8
     "@mui/material": 5.11.0
-    "@storyblok/field-plugin": 0.0.1-alpha.2
+    "@storyblok/field-plugin": 0.0.1-alpha.3
     "@storyblok/mui": 0.0.22
     "@types/react-dom": ^18.0.10
     "@vitejs/plugin-react": ^3.0.0


### PR DESCRIPTION
## What?

BREAKING CHANGES:

- `setHeight` removed from `FieldPluginActions`.
- `height` removed from `FieldPluginData`.

Non-breaking changes:

- The sandbox was refactored to use the terminology `content` instead of `value`
- The sandbox removed the height from the `FieldPluginResponse.data` view.
- The sandbox changed the name of `isModalOpen` from incorrect `isModal` from the `FieldPluginResponse.data` view.
- Upgrading to Typescript v5 so that we can use `satisfies` in the container

## Why?

Because the automatic resizing will call setHeight, the developer will not be in control of the height. But if we expose it via FieldPluginActions, we’re leading the API consumers to believe that they can influence the height. Any such usage of setHeight would interfere with the automatic resizing. 

If we remove it from FieldPluginActions then nothing new will happen. setHeight is not used in the templates, only internally in createFieldPlugin.

Furthermore, I discovered a bug where `FieldPluginData.height` was not being updated, because the auto resizer was not using `actions.setHeight` to update the height, but was directly sending messages to the container. But `FieldPluginData.height` was only being changed when `FieldPluginActions.setHeight` was being called. `FieldPluginData.height` was added because it was so easy to do, but I do not see a use case for it either, so we can remove it together with `FieldPluginActions.setHeight`.

## How to test

See the Sandbox's preview deployment 