### PR TITLE
feat(sandbox): Reading sandbox origin from `window.location`

### DIFF
--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -40,6 +40,10 @@ import { UrlView } from './UrlView'
 import { StoryData } from '@storyblok/field-plugin'
 
 const defaultUrl = 'http://localhost:8080'
+const initialStory: StoryData = {
+  content: {},
+  lang: 'default',
+}
 const initialContent = ''
 const initialHeight = 300
 const initialWidth = 300
@@ -92,9 +96,7 @@ const useSandbox = (
   }, [fieldPluginURL, pluginParams])
   const [iframeUid, setIframeUid] = useState(uid)
 
-  const [story, setStory] = useState<StoryData>({
-    content: {},
-  })
+  const [story] = useState<StoryData>(initialStory)
 
   // TODO replace with useReducer
   const [isModalOpen, setModalOpen] = useState(false)

--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -12,9 +12,9 @@ import {
   FieldPluginData,
   FieldPluginSchema,
   originFromPluginParams,
-  PluginUrlParams,
   recordFromFieldPluginOptions,
   StateChangedMessage,
+  StoryData,
   urlSearchParamsFromPluginUrlParams,
 } from '@storyblok/field-plugin'
 import '@fontsource/roboto/300.css'
@@ -37,7 +37,7 @@ import { ContentView } from './ContentView'
 import { StringParam, useQueryParam, withDefault } from 'use-query-params'
 import { ObjectView } from './ObjectView'
 import { UrlView } from './UrlView'
-import { StoryData } from '@storyblok/field-plugin'
+import { usePluginParams } from './usePluginParams'
 
 const defaultUrl = 'http://localhost:8080'
 const initialStory: StoryData = {
@@ -49,18 +49,6 @@ const initialHeight = 300
 const initialWidth = 300
 
 const UrlQueryParam = withDefault(StringParam, defaultUrl)
-
-const usePluginParams = () => {
-  return useMemo<PluginUrlParams>(
-    () => ({
-      uid: Math.random().toString(32).slice(2),
-      host: window.location.host,
-      secure: window.location.protocol === 'https:',
-      preview: true,
-    }),
-    [],
-  )
-}
 
 const useSandbox = (
   onError: (message: { title: string; message?: string }) => void,

--- a/packages/container/src/components/usePluginParams.tsx
+++ b/packages/container/src/components/usePluginParams.tsx
@@ -1,0 +1,14 @@
+import { useMemo } from 'react'
+import { PluginUrlParams } from '@storyblok/field-plugin'
+
+export const usePluginParams = () => {
+  return useMemo<PluginUrlParams>(
+    () => ({
+      uid: Math.random().toString(32).slice(2),
+      host: window.location.host,
+      secure: window.location.protocol === 'https:',
+      preview: true,
+    }),
+    [],
+  )
+}


### PR DESCRIPTION
## What?

When selecting an asset, the sandbox will respond with an image that is served from the URL where the sandbox is hosted.

## Why?

JIRA: EXT-1478

To make the sandbox's asset selector work when deployed. Previously, `http://localhost:7070` was hard coded.

## How to test? (optional)

Try the Vercel preview 