### PR TITLE
chore(ci): do not run template tests when upgrading the library version

### DIFF
--- a/.github/workflows/template-js.yml
+++ b/.github/workflows/template-js.yml
@@ -6,6 +6,7 @@ on:
       - 'packages/field-plugin/**'
 jobs:
   build:
+    if: "!startsWith(github.event.pull_request.title, 'chore(lib): release @storyblok/field-plugin@')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/template-react.yml
+++ b/.github/workflows/template-react.yml
@@ -6,6 +6,7 @@ on:
       - 'packages/field-plugin/**'
 jobs:
   build:
+    if: "!startsWith(github.event.pull_request.title, 'chore(lib): release @storyblok/field-plugin@')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/template-vue2.yml
+++ b/.github/workflows/template-vue2.yml
@@ -6,6 +6,7 @@ on:
       - 'packages/field-plugin/**'
 jobs:
   build:
+    if: "!startsWith(github.event.pull_request.title, 'chore(lib): release @storyblok/field-plugin@')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/template-vue3.yml
+++ b/.github/workflows/template-vue3.yml
@@ -6,6 +6,7 @@ on:
       - 'packages/field-plugin/**'
 jobs:
   build:
+    if: "!startsWith(github.event.pull_request.title, 'chore(lib): release @storyblok/field-plugin@')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What?

This PR prevents the templates CI tasks from running when upgrading the library version.

## Why?

When we create a pull-request to upgrade the library version [like this](https://github.com/storyblok/field-plugin/pull/182), problem happens.

For example,

1. The library version was 3, and the templates were depending on the library version 3.
2. All the CI tasks are running fine.
3. We bump the library version to 4, and the templates are still depending on 3.
4. Now the CI tasks for the templates are resolving v3 from NPM, not the local v4 (which makes sense).
5. We have a breaking change in the library (3 → 4), and the changes are applied to the templates. But at the step 4, by resolving v3 instead of v4, the templates are using something from the library that doesn't exist. And the CI fails.

### An approach I tried:
1. I tried to bump the library version, and update all the templates to depend on the new version at the same time in a single PR.
2. Some tasks ran correctly because yarn resolved the local version correctly (the library is v4, and the templates are depending on v4).
3. Some other tasks fail with the following commands:

```
yarn workspace @storyblok/field-plugin-cli build
npx field-plugin --dir=${{runner.temp}} --pluginName=temp-single-field-plugin --template=vue2 --structure=polyrepo
```
↑ There is a new repo made with templates depending on v4, but it doesn't exist yet. And it's now out of the monorepo, so it fails to resolve the library.

### So what this PR actually does is,

It skips the CI tasks on the templates IF a pull-request title starts with "chore(lib): release @storyblok/field-plugin@". That means that we're releasing the library. We're not touching anything else in the codebase. No need to test the templates.

A couple of minutes after we release the library, we're going to update all the templates to depend on the new library version. And while we try to release the templates, we'll get to test them anyway.