### PR TITLE
chore(common): fix workflows to check pull-request title correctly

### DIFF
--- a/.github/workflows/check-if-releasing-library.yml
+++ b/.github/workflows/check-if-releasing-library.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_call:
+    outputs:
+      result:
+        value: ${{ jobs.check-if-releasing-library.outputs.result }}
+
+jobs:
+  check-if-releasing-library:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.validation.outputs.result }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: PR
+        uses: jwalton/gh-find-current-pr@v1
+      - id: validation
+        run: |
+          if [[ "${{ steps.PR.outputs.title }}" == "@storyblok/field-plugin-cli@"* ]]; then
+            echo "releasing library"
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "not releasing library"
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/template-js.yml
+++ b/.github/workflows/template-js.yml
@@ -5,8 +5,11 @@ on:
       - 'packages/cli/templates/js/**'
       - 'packages/field-plugin/**'
 jobs:
+  check-if-releasing-library:
+    uses: ./.github/workflows/check-if-releasing-library.yml
   build:
-    if: ${{ !startsWith(github.event.pull_request.title, 'chore(lib): release @storyblok/field-plugin@') }}
+    needs: check-if-releasing-library
+    if: ${{ needs.check-if-releasing-library.outputs.result == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/template-react.yml
+++ b/.github/workflows/template-react.yml
@@ -5,8 +5,11 @@ on:
       - 'packages/cli/templates/react/**'
       - 'packages/field-plugin/**'
 jobs:
+  check-if-releasing-library:
+    uses: ./.github/workflows/check-if-releasing-library.yml
   build:
-    if: ${{ !startsWith(github.event.pull_request.title, 'chore(lib): release @storyblok/field-plugin@') }}
+    needs: check-if-releasing-library
+    if: ${{ needs.check-if-releasing-library.outputs.result == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/template-vue2.yml
+++ b/.github/workflows/template-vue2.yml
@@ -5,8 +5,11 @@ on:
       - 'packages/cli/templates/vue2/**'
       - 'packages/field-plugin/**'
 jobs:
+  check-if-releasing-library:
+    uses: ./.github/workflows/check-if-releasing-library.yml
   build:
-    if: ${{ !startsWith(github.event.pull_request.title, 'chore(lib): release @storyblok/field-plugin@') }}
+    needs: check-if-releasing-library
+    if: ${{ needs.check-if-releasing-library.outputs.result == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/template-vue3.yml
+++ b/.github/workflows/template-vue3.yml
@@ -5,8 +5,11 @@ on:
       - 'packages/cli/templates/vue3/**'
       - 'packages/field-plugin/**'
 jobs:
+  check-if-releasing-library:
+    uses: ./.github/workflows/check-if-releasing-library.yml
   build:
-    if: ${{ !startsWith(github.event.pull_request.title, 'chore(lib): release @storyblok/field-plugin@') }}
+    needs: check-if-releasing-library
+    if: ${{ needs.check-if-releasing-library.outputs.result == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What?

This PR fixes the wrong implementation of https://github.com/storyblok/field-plugin/pull/184


## Why?

Template CI tasks run on `push` trigger: https://github.com/storyblok/field-plugin/blob/658f5454ca9f93b9e680ad86a61c355371253212/.github/workflows/template-vue3.yml#L2-L3

In that context, we don't have access to `github.event.pull_request`. It exists only on `pull_request` trigger.

So in this PR, I've added `check-if-releasing-library.yml` which uses `jwalton/gh-find-current-pr@v1` action to retrieve the pull-request title and validates it.

And all the other `template-*.yml` workflows depend on this check file and uses its result.

## References

https://docs.github.com/en/actions/using-workflows/reusing-workflows