### PR TITLE
fix(sandbox): broken reload plugin button

### DIFF
--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -57,7 +57,7 @@ const UrlQueryParam = withDefault(StringParam, defaultUrl)
 const useSandbox = (
   onError: (message: { title: string; message?: string }) => void,
 ) => {
-  const pluginParams = usePluginParams()
+  const { pluginParams, randomizeUid } = usePluginParams()
   const { uid } = pluginParams
 
   const fieldTypeIframe = useRef<HTMLIFrameElement>(null)
@@ -98,10 +98,6 @@ const useSandbox = (
     options: [],
   })
   const [content, setContent] = useState<unknown>(initialContent)
-
-  const refreshIframe = () => {
-    setIframeKey((key) => key + 1)
-  }
 
   const loadedData = useMemo<StateChangedMessage>(
     () => ({
@@ -222,13 +218,12 @@ const useSandbox = (
       url,
       fieldTypeIframe,
       iframeSrc,
-      iframeUid: iframeKey,
     },
     {
       setContent,
       setSchema,
       setUrl,
-      refreshIframe,
+      randomizeUid,
     },
   ] as const
 }
@@ -236,17 +231,8 @@ const useSandbox = (
 export const FieldPluginContainer: FunctionComponent = () => {
   const { error } = useNotifications()
   const [
-    {
-      content,
-      isModalOpen,
-      height,
-      schema,
-      url,
-      fieldTypeIframe,
-      iframeSrc,
-      iframeUid,
-    },
-    { setContent, setSchema, setUrl, refreshIframe },
+    { content, isModalOpen, height, schema, url, fieldTypeIframe, iframeSrc },
+    { setContent, setSchema, setUrl, randomizeUid },
   ] = useSandbox(error)
 
   return (
@@ -278,7 +264,6 @@ export const FieldPluginContainer: FunctionComponent = () => {
               height={`${height}px`}
               isModal={isModalOpen}
               ref={fieldTypeIframe}
-              iframeKey={iframeUid}
             />
           </CenteredContent>
         </AccordionDetails>
@@ -287,7 +272,8 @@ export const FieldPluginContainer: FunctionComponent = () => {
         <UrlView
           url={url}
           setUrl={setUrl}
-          onRefresh={refreshIframe}
+          // Randomizing the uid will change the url which in turn refreshes the iframe window
+          onRefresh={randomizeUid}
           error={typeof iframeSrc === 'undefined'}
           placeholder={defaultUrl}
         />

--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -86,7 +86,7 @@ const useSandbox = (
       fieldPluginURL.pathname
     }?${urlSearchParamsFromPluginUrlParams(pluginParams)}`
   }, [fieldPluginURL, pluginParams])
-  const [iframeUid, setIframeUid] = useState(uid)
+  const [iframeKey, setIframeKey] = useState(0)
 
   const [story] = useState<StoryData>(initialStory)
 
@@ -100,7 +100,7 @@ const useSandbox = (
   const [content, setContent] = useState<unknown>(initialContent)
 
   const refreshIframe = () => {
-    setIframeUid(uid)
+    setIframeKey((key) => key + 1)
   }
 
   const loadedData = useMemo<StateChangedMessage>(
@@ -222,7 +222,7 @@ const useSandbox = (
       url,
       fieldTypeIframe,
       iframeSrc,
-      iframeUid,
+      iframeUid: iframeKey,
     },
     {
       setContent,
@@ -278,7 +278,7 @@ export const FieldPluginContainer: FunctionComponent = () => {
               height={`${height}px`}
               isModal={isModalOpen}
               ref={fieldTypeIframe}
-              uid={iframeUid}
+              iframeKey={iframeUid}
             />
           </CenteredContent>
         </AccordionDetails>

--- a/packages/container/src/components/FieldTypePreview.tsx
+++ b/packages/container/src/components/FieldTypePreview.tsx
@@ -74,7 +74,7 @@ export const FieldTypePreview = forwardRef<
     height: string
     isModal: boolean
     // Allows the iframe to be refreshed
-    uid?: string
+    iframeKey?: number
     sx?: SxProps
   }
 >(function FieldTypePreview(props, ref) {
@@ -90,7 +90,7 @@ export const FieldTypePreview = forwardRef<
           {typeof props.src !== 'undefined' ? (
             <Box
               ref={ref}
-              key={props.uid}
+              key={props.iframeKey}
               component="iframe"
               src={props.src}
               title="Field Plugin Preview"

--- a/packages/container/src/components/usePluginParams.tsx
+++ b/packages/container/src/components/usePluginParams.tsx
@@ -1,14 +1,22 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { PluginUrlParams } from '@storyblok/field-plugin'
 
+const randomString = () => Math.random().toString(32).slice(2)
+
 export const usePluginParams = () => {
-  return useMemo<PluginUrlParams>(
+  const [uid, setUid] = useState(randomString)
+  const randomizeUid = useCallback(() => setUid(randomString), [])
+  const pluginParams = useMemo<PluginUrlParams>(
     () => ({
-      uid: Math.random().toString(32).slice(2),
+      uid,
       host: window.location.host,
       secure: window.location.protocol === 'https:',
       preview: true,
     }),
-    [],
+    [uid],
   )
+  return {
+    pluginParams,
+    randomizeUid,
+  }
 }


### PR DESCRIPTION
## What?

Fixes the _reload plugin_ button.

<img width="773" alt="image" src="https://github.com/storyblok/field-plugin/assets/14206504/4861a548-972d-478b-8d18-90a8df42d0b1">

The way we refreshed the iframe window was by utilizing a trick from React. By setting the `key` on the react element and thereafter changing it, we force React to insert a new iframe element into the document.

The key that we used was a random string that we would regenerate on a function call. We called this calue a "uid". But in previous refactoring, the key was accidentally mixed up with the uid from the `pluginParams` object, which we never update. Thus, the functionality was broken.

We avoid this problem from happening again by removing the key property from the iframe. Instead, we will force a refresh of the iframe window by changing the URL. We do this by updating the `uid` in the query parameters, which we find in the `pluginParams` object.


## Why?

JIRA: EXT-1557

## How to test? (optional)

See preview