### PR TITLE
fix(demo): updated styles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,4 +17,5 @@ jobs:
             sandbox
             cli
             template
+            demo
           requireScope: true

--- a/packages/demo/src/components/AssetSelector.tsx
+++ b/packages/demo/src/components/AssetSelector.tsx
@@ -9,9 +9,7 @@ export const AssetSelector: PluginComponent = (props) => {
   const [asset, setAsset] = useState<Asset | undefined>()
   return (
     <Stack gap={2}>
-      <Divider>
-        <Typography variant="subtitle1">Asset Selector</Typography>
-      </Divider>
+      <Typography variant="subtitle1">Asset Selector</Typography>
       <Box
         height={100}
         position="relative"

--- a/packages/demo/src/components/AssetSelector.tsx
+++ b/packages/demo/src/components/AssetSelector.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Box, Button, Divider, Stack, Typography } from '@mui/material'
+import { Box, Button, Stack, Typography } from '@mui/material'
 import { AssetIcon, DeleteIcon } from '@storyblok/mui'
 import { PluginComponent } from './FieldPluginDemo'
 import { Asset } from '@storyblok/field-plugin'

--- a/packages/demo/src/components/ContextRequester.tsx
+++ b/packages/demo/src/components/ContextRequester.tsx
@@ -1,13 +1,11 @@
-import { Button, Divider, Stack, Typography } from '@mui/material'
+import { Button, Stack, Typography } from '@mui/material'
 import { PluginComponent } from './FieldPluginDemo'
 
 export const ContextRequester: PluginComponent = (props) => {
   const { data, actions } = props
   return (
     <Stack gap={2}>
-      <Divider>
-        <Typography variant="subtitle1">Story</Typography>
-      </Divider>
+      <Typography variant="subtitle1">Story</Typography>
       <Typography textAlign="center">{JSON.stringify(data.story)}</Typography>
       <Button
         variant="outlined"

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -38,7 +38,9 @@ export const FieldPluginDemo: FunctionComponent = () => {
     actions,
   }
   return (
-    <Paper sx={{ p: 3, borderColor: 'divider', border: 1 }}>
+    <Paper
+      sx={{ p: 3, border: (theme) => `1px dashed ${theme.palette.divider}` }}
+    >
       <Stack gap={4}>
         <ValueMutator {...props} />
         <Divider />

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -39,7 +39,7 @@ export const FieldPluginDemo: FunctionComponent = () => {
   }
   return (
     <Paper
-      sx={{ p: 3, border: (theme) => `1px dashed ${theme.palette.divider}` }}
+      sx={{ p: 3, border: (theme) => `1px solid ${theme.palette.divider}` }}
     >
       <Stack gap={4}>
         <ValueMutator {...props} />

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -42,15 +42,11 @@ export const FieldPluginDemo: FunctionComponent = () => {
     <Paper
       sx={{ p: 3, border: (theme) => `1px solid ${theme.palette.divider}` }}
     >
-      <Stack gap={4}>
+      <Stack gap={6}>
         <ValueMutator {...props} />
-        <Divider />
         <UpdaterFunctionDemo {...props} />
-        <Divider />
         <ModalToggle {...props} />
-        <Divider />
         <AssetSelector {...props} />
-        <Divider />
         <ContextRequester {...props} />
       </Stack>
     </Paper>

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react'
-import { Box, Stack, Typography } from '@mui/material'
+import { Box, Divider, Paper, Stack, Typography } from '@mui/material'
 import { useFieldPlugin } from '../useFieldPlugin'
 import { LoadingIcon, SquareErrorIcon } from '@storyblok/mui'
 import { FieldPluginActions, FieldPluginData } from '@storyblok/field-plugin'
@@ -38,11 +38,16 @@ export const FieldPluginDemo: FunctionComponent = () => {
     actions,
   }
   return (
-    <Stack gap={4}>
-      <ValueMutator {...props} />
-      <ModalToggle {...props} />
-      <AssetSelector {...props} />
-      <ContextRequester {...props} />
-    </Stack>
+    <Paper sx={{ p: 3, borderColor: 'divider', border: 1 }}>
+      <Stack gap={4}>
+        <ValueMutator {...props} />
+        <Divider />
+        <ModalToggle {...props} />
+        <Divider />
+        <AssetSelector {...props} />
+        <Divider />
+        <ContextRequester {...props} />
+      </Stack>
+    </Paper>
   )
 }

--- a/packages/demo/src/components/ModalToggle.tsx
+++ b/packages/demo/src/components/ModalToggle.tsx
@@ -1,19 +1,11 @@
-import {
-  Divider,
-  FormControlLabel,
-  Stack,
-  Switch,
-  Typography,
-} from '@mui/material'
+import { FormControlLabel, Stack, Switch, Typography } from '@mui/material'
 import { PluginComponent } from './FieldPluginDemo'
 
 export const ModalToggle: PluginComponent = (props) => {
   const { data, actions } = props
   return (
     <Stack gap={2}>
-      <Divider>
-        <Typography variant="subtitle1">Modal</Typography>
-      </Divider>
+      <Typography variant="subtitle1">Modal</Typography>
       <FormControlLabel
         control={<Switch defaultChecked />}
         checked={data.isModalOpen}

--- a/packages/demo/src/components/ValueMutator.tsx
+++ b/packages/demo/src/components/ValueMutator.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, Stack, Typography } from '@mui/material'
+import { Button, Stack, Typography } from '@mui/material'
 import { PluginComponent } from './FieldPluginDemo'
 
 export const ValueMutator: PluginComponent = (props) => {
@@ -15,9 +15,7 @@ export const ValueMutator: PluginComponent = (props) => {
 
   return (
     <Stack gap={2}>
-      <Divider>
-        <Typography variant="subtitle1">Field Value</Typography>
-      </Divider>
+      <Typography variant="subtitle1">Field Value</Typography>
       <Typography textAlign="center">{label}</Typography>
       <Button
         variant="outlined"


### PR DESCRIPTION
## What?

Updated styles for the demo app:

- white background with padding and a grey border
- headers and dividers are separated

<img width="870" alt="image" src="https://github.com/storyblok/field-plugin/assets/14206504/c251f6bf-92ec-4bd6-99c9-e3aa35ba3e75">

Also adding a new scope `demo` to the pull request title check.

## Why?

The background was transparent, so the grey background in the Sandbox/Visual Editor made it hard to read.

## How to test


Run locally