### PR TITLE
feat(lib): updater functions

### DIFF
--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -7,6 +7,7 @@ import { ValueMutator } from './ValueMutator'
 import { ModalToggle } from './ModalToggle'
 import { AssetSelector } from './AssetSelector'
 import { ContextRequester } from './ContextRequester'
+import { UpdaterFunctionDemo } from './UpdaterFunctionDemo'
 
 export type PluginComponent = FunctionComponent<{
   data: FieldPluginData
@@ -40,6 +41,7 @@ export const FieldPluginDemo: FunctionComponent = () => {
   return (
     <Stack gap={4}>
       <ValueMutator {...props} />
+      <UpdaterFunctionDemo {...props} />
       <ModalToggle {...props} />
       <AssetSelector {...props} />
       <ContextRequester {...props} />

--- a/packages/demo/src/components/UpdaterFunctionDemo.tsx
+++ b/packages/demo/src/components/UpdaterFunctionDemo.tsx
@@ -1,0 +1,37 @@
+import { Button, Stack, Typography } from '@mui/material'
+import { PluginComponent } from './FieldPluginDemo'
+
+export const UpdaterFunctionDemo: PluginComponent = (props) => {
+  const { data, actions } = props
+
+  const handleClickIncrement = () => {
+    actions?.setContent(
+      (content) => (typeof content === 'number' ? content : 0) + 1,
+    )
+    actions?.setContent(
+      (content) => (typeof content === 'number' ? content : 0) + 1,
+    )
+  }
+  const label =
+    typeof data.content === 'undefined'
+      ? 'undefined'
+      : JSON.stringify(data.content)
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="subtitle1">Field Value</Typography>
+      <Typography>
+        Increment the counter twice by calling <code>setContent</code> two times
+        consecutively in between two renders.
+      </Typography>
+      <Typography textAlign="center">{label}</Typography>
+      <Button
+        variant="outlined"
+        color="secondary"
+        onClick={handleClickIncrement}
+      >
+        Increment twice
+      </Button>
+    </Stack>
+  )
+}

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
@@ -1,9 +1,10 @@
 import { Asset } from '../messaging'
 
+type DispatchAction<T> = T | ((value: T) => T)
 export type SetContent = <Content = undefined>(
-  setContentAction: Content | ((content: Content) => void),
+  setContentAction: DispatchAction<Content>,
 ) => void
-export type SetModalOpen = (isModal: boolean) => void
+export type SetModalOpen = (setModalOpenAction: DispatchAction<boolean>) => void
 export type RequestContext = () => void
 export type SelectAsset = () => Promise<Asset>
 

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
@@ -1,6 +1,8 @@
 import { Asset } from '../messaging'
 
-export type SetContent = (content: unknown) => void
+export type SetContent = <Content = undefined>(
+  setContentAction: Content | ((content: Content) => void),
+) => void
 export type SetModalOpen = (isModal: boolean) => void
 export type RequestContext = () => void
 export type SelectAsset = () => Promise<Asset>

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
@@ -1,9 +1,7 @@
 import { Asset } from '../messaging'
 
-type DispatchAction<T> = T | ((value: T) => T)
-export type SetContent = <Content = undefined>(
-  setContentAction: DispatchAction<Content>,
-) => void
+export type DispatchAction<T> = T | ((value: T) => T)
+export type SetContent = <C>(setContentAction: DispatchAction<C>) => void
 export type SetModalOpen = (setModalOpenAction: DispatchAction<boolean>) => void
 export type RequestContext = () => void
 export type SelectAsset = () => Promise<Asset>

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
@@ -1,8 +1,8 @@
 import { Asset } from '../messaging'
 
-export type DispatchAction<T> = T | ((value: T) => T)
-export type SetContent = <C>(setContentAction: DispatchAction<C>) => void
-export type SetModalOpen = (setModalOpenAction: DispatchAction<boolean>) => void
+export type SetStateAction<T> = T | ((value: T) => T)
+export type SetContent = <C>(setContentAction: SetStateAction<C>) => void
+export type SetModalOpen = (setModalOpenAction: SetStateAction<boolean>) => void
 export type RequestContext = () => void
 export type SelectAsset = () => Promise<Asset>
 

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -95,7 +95,12 @@ export const createPluginActions: CreatePluginActions = (
 
   return {
     actions: {
-      setContent: (content) => {
+      setContent: (contentOrUpdaterFunction) => {
+        const content: unknown =
+          typeof contentOrUpdaterFunction === 'function'
+            ? contentOrUpdaterFunction(state.content)
+            : contentOrUpdaterFunction
+        console.log(typeof contentOrUpdaterFunction, content)
         postToContainer(valueChangeMessage(uid, content))
         state = {
           ...state,

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -95,12 +95,9 @@ export const createPluginActions: CreatePluginActions = (
 
   return {
     actions: {
-      setContent: (contentOrUpdaterFunction) => {
+      setContent: (action) => {
         const content: unknown =
-          typeof contentOrUpdaterFunction === 'function'
-            ? contentOrUpdaterFunction(state.content)
-            : contentOrUpdaterFunction
-        console.log(typeof contentOrUpdaterFunction, content)
+          typeof action === 'function' ? action(state.content) : action
         postToContainer(valueChangeMessage(uid, content))
         state = {
           ...state,
@@ -108,7 +105,9 @@ export const createPluginActions: CreatePluginActions = (
         }
         onUpdateState(state)
       },
-      setModalOpen: (isModalOpen) => {
+      setModalOpen: (action) => {
+        const isModalOpen: boolean =
+          typeof action === 'function' ? action(state.isModalOpen) : action
         postToContainer(modalChangeMessage(uid, isModalOpen))
         state = {
           ...state,

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -97,6 +97,10 @@ export const createPluginActions: CreatePluginActions = (
     actions: {
       setContent: (action) => {
         const content: unknown =
+          // This is not safe: if the user pass a function to setContent(),
+          //  this code assumes that it is an updater function
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           typeof action === 'function' ? action(state.content) : action
         postToContainer(valueChangeMessage(uid, content))
         state = {
@@ -106,7 +110,7 @@ export const createPluginActions: CreatePluginActions = (
         onUpdateState(state)
       },
       setModalOpen: (action) => {
-        const isModalOpen: boolean =
+        const isModalOpen =
           typeof action === 'function' ? action(state.isModalOpen) : action
         postToContainer(modalChangeMessage(uid, isModalOpen))
         state = {


### PR DESCRIPTION
Issue: EXT-1558

## What?

`setContent`  and `setModalOpen` now accept updater functions as arguments.

## Why?

In React and other frameworks with batched updates, unless you update a state with an updater function, multiple calls to `setState` will result in only a single update, because the latter updates overwrite the previous ones.

The same thing can happen in a field plugin with `setContent` and `setModalOpen`.

## How to test? (optional)

Run the demo and try out the new button "IncrementTwice".

<img width="774" alt="image" src="https://github.com/storyblok/field-plugin/assets/14206504/a8f2ff3b-6047-42f6-b2f6-78bbc14a5773">

(The background is being fixed in #205)