### PR TITLE
fix(common): use @beta instead of @alpha with the cli 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It's easy to get started! Simply
 use [Storyblok's field plugin CLI](https://www.npmjs.com/package/@storyblok/field-plugin-cli) to bootstrap your project with your favorite frontend framework:
 
 ```shell
-npx @storyblok/field-plugin-cli@alpha
+npx @storyblok/field-plugin-cli@beta
 ```
 
 Storyblok provides the following starter projects:
@@ -23,7 +23,7 @@ Storyblok provides the following starter projects:
 To integrate `@storyblok/field-plugin` into a frontend framework, bootstrap your application with the `--template js` flag.
 
 ```shell
-npx @storyblok/field-plugin-cli@alpha --template js
+npx @storyblok/field-plugin-cli@beta --template js
 ```
 
 The entry point of the application is in `src/main.js`. Replace this code with the following:
@@ -197,7 +197,7 @@ Properties:
 
 ## Caveats
 
-Field plugins for Storyblok have some unique feature that one should be aware of. It can be tricky to set up a new project from scratch, and it is therefore recommended to bootstrap new projects with `npx @storyblok/field-plugin-cli@alpha`.
+Field plugins for Storyblok have some unique feature that one should be aware of. It can be tricky to set up a new project from scratch, and it is therefore recommended to bootstrap new projects with `npx @storyblok/field-plugin-cli@beta`.
 
 ### Single JavaScript Bundle
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,17 +1,21 @@
 # Storyblok Field Plugin CLI
-[//]: # (TBD Add storyblok social media and package links)
+
+[//]: # 'TBD Add storyblok social media and package links'
 
 The Storyblok Field Plugin Command Line Interface provides functionality to create and deploy your field plugins in a much smoother and more intuitive way. To get started, use the following command:
 
 ## Usage
+
 In case no command is present the CLI will default to the `create` command.
 
-[//]: # (TBD: add yarn create as soon as it is implemented)
+[//]: # 'TBD: add yarn create as soon as it is implemented'
 
 ```bash
-npx @storyblok/field-plugin-cli@alpha [command] [options]
+npx @storyblok/field-plugin-cli@beta [command] [options]
 ```
+
 Available options and commands:
+
 ```bash
 Options:
   -V, --version     output the version number
@@ -23,9 +27,11 @@ Commands:
   add    [options]  adds new field-plugin inside your project
   help   [command]  display help for command
 ```
-[//]: # (TBD Add GIF with interactive mode)
+
+[//]: # 'TBD Add GIF with interactive mode'
 
 ### create
+
 The `create` command allows a set of **optional** options for customization.
 
 ```bash
@@ -38,6 +44,7 @@ The `create` command allows a set of **optional** options for customization.
 ```
 
 #### Examples
+
 ```bash
 # Run this simple command and you will be prompted to provide all required information
 npx @storyblok/field-plugin-cli
@@ -53,10 +60,13 @@ npx @storyblok/field-plugin-cli create --dir=<PATH_TO_DIR> --pluginName=<FIELD_P
 ```
 
 #### Structure
+
 Sometimes you might want to create only a single field plugin. At other times you might want to create and maintain multiple field plugins all in one repository. In both cases we have got you covered. The CLI supports both a polyrepo and a monorepo setup.
 
 ##### polyrepo (one package in one repo)
+
 Here is a simplified folder structure of a polyrepo mode:
+
 ```bash
 ├── field-plugin
 │   ├── src
@@ -68,7 +78,9 @@ Here is a simplified folder structure of a polyrepo mode:
 ```
 
 #### monorepo (multiple packages in one repo)
+
 For a monorepo setup, we are using the following project structure:
+
 ```bash
 ├── field-plugins
 │   ├── packages
@@ -83,9 +95,11 @@ For a monorepo setup, we are using the following project structure:
 │   └── package.json
 └── ...
 ```
-[//]: # (TBD Add GIF with interactive mode)
+
+[//]: # 'TBD Add GIF with interactive mode'
 
 ### add
+
 The options for the `add` command are the following:
 
 ```bash
@@ -94,7 +108,9 @@ The options for the `add` command are the following:
 --dir <value>       directory to create a field plugin into (default: `.`)
 -h, --help          display help for command
 ```
+
 #### Examples
+
 ```bash
 # Run this simple command and you will be prompted to provide all required information
 npx @storyblok/field-plugin-cli add
@@ -105,16 +121,19 @@ npx @storyblok/field-plugin-cli add --name=<FIELD_PLUGIN_NAME> --template=vue3 -
 # Add field plugin with React template to a project outside of the current directory
 npx @storyblok/field-plugin-cli add --name=<FIELD_PLUGIN_NAME> --template=react --dir=<PATH_TO_DIR>
 ```
-[//]: # (TBD Add GIF with interactive mode)
+
+[//]: # 'TBD Add GIF with interactive mode'
 
 ### deploy
+
 Uploading your field plugin implementation to Storyblok Partner Portal can be performed by simply running the `deploy` command.
 
-[//]: # (Add information about deploy and what is specifically does - uploading content of a file to SB, not building)
+[//]: # 'Add information about deploy and what is specifically does - uploading content of a file to SB, not building'
 
->:warning: A token to access the [Storyblok Management API](https://www.storyblok.com/docs/api/management) for upserting the field plugin **must** be provided. There are two ways how to pass a token to the CLI.
+> :warning: A token to access the [Storyblok Management API](https://www.storyblok.com/docs/api/management) for upserting the field plugin **must** be provided. There are two ways how to pass a token to the CLI.
+>
 > 1. provide `--token <STORYBLOK_PERSONAL_ACCESS_TOKEN>` inside the `deploy` command
-> 2. inside `.env` or `.env.local` create a new variable `STORYBLOK_PERSONAL_ACCESS_TOKEN` 
+> 2. inside `.env` or `.env.local` create a new variable `STORYBLOK_PERSONAL_ACCESS_TOKEN`
 
 For additional customizations you can add the following options to the command:
 
@@ -127,6 +146,7 @@ For additional customizations you can add the following options to the command:
 ```
 
 #### Examples
+
 ```bash
 # Run this simple command and you will be prompted to provide all required information. NOTE: This command will work only if you have created STORYBLOK_PERSONAL_ACCESS_TOKEN as an environmental variable inside .env or .env.local!
 npx @storyblok/field-plugin-cli deploy
@@ -141,29 +161,36 @@ npx @storyblok/field-plugin-cli deploy --token=<TOKEN> --skipPrompts
 npx @storyblok/field-plugin-cli deploy --token=<TOKEN> --dir=<PATH_TO_DIR>
 ```
 
-[//]: # (Add snippet for root script to deploy a package)
+[//]: # 'Add snippet for root script to deploy a package'
 
 ## :electric_plug: Installation
+
 You can add the CLI to an existing field plugin project by running:
+
 ```bash
-yarn add --dev @storyblok/field-plugin-cli@alpha
+yarn add --dev @storyblok/field-plugin-cli@beta
 ```
 
 In case you want to access the dependency globally use:
+
 ```bash
-yarn global add @storyblok/field-plugin-cli@alpha 
+yarn global add @storyblok/field-plugin-cli@beta
 # or
-npm install @storyblok/field-plugin-cli@alpha --global
+npm install @storyblok/field-plugin-cli@beta --global
 ```
 
-[//]: # (TBD Add GIF with interactive mode)
+[//]: # 'TBD Add GIF with interactive mode'
+
 ## :people_hugging: Supported Frameworks
+
 We are working on providing templates for the popular frontend frameworks. Currently, our CLI includes templates created with:
+
 - React
 - Vue 3
 - Vue 2
 
 ## :books: What's next?
+
 Now that everything is set up you can go ahead and checkout Storyblok's resource on field plugins:
 
 🔗 [Field Plugin Documentation](https://www.storyblok.com/docs/plugins/field-type)
@@ -173,28 +200,31 @@ Now that everything is set up you can go ahead and checkout Storyblok's resource
 🔗 [Webinar Feature Focus: Field Plugin](https://www.youtube.com/watch?v=fvTWZCACDVQ)
 
 ## :seedling: Contributing
+
 Please see our [contributing guidelines](https://github.com/storyblok/.github/blob/master/contributing.md). We are always looking for feedback to create a better developer experience. If you happen to find a bug or simply would like to suggest a new feature, you can do so by [submitting an issue](https://github.com/storyblok/field-plugin/issues).
 
 When adding a new template to this repository, think of the following:
 
-- `.gitignore` files must be named `gitignore`. Otherwise, NPM will exclude the file from the release. The `@storyblok/field-plugin-cli` will automatically rename the file to `.gitignore`.  
-- Add `"deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"` to the `package.json`
+- `.gitignore` files must be named `gitignore`. Otherwise, NPM will exclude the file from the release. The `@storyblok/field-plugin-cli` will automatically rename the file to `.gitignore`.
+- Add `"deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"` to the `package.json`
 
 ## :1st_place_medal: Credits
+
 Special thanks goes to all the people that contribute to this library!
 
 <a href="https://github.com/storyblok/field-plugin/graphs/contributors">
   <img alt='contributors' src="https://contrib.rocks/image?repo=storyblok/field-plugin"/>
 </a>
 
-[//]: # (TBD provide information on semantic naming conventions for brnaches?)
+[//]: # 'TBD provide information on semantic naming conventions for brnaches?'
 
 ## :construction: Roadmap
+
 In the future, we would like to add more functionality to the CLI such as:
+
 - [ ] Support for different package managers (npm, pnpm)
 - [ ] Initializing git when creating a new field plugin and + option to opt out
 
-
-[//]: # (TBD)
-[//]: # (CI/CD - provide examples for how to setup a flow for ci/cd)
-[//]: # (Known Limitations)
+[//]: # 'TBD'
+[//]: # 'CI/CD - provide examples for how to setup a flow for ci/cd'
+[//]: # 'Known Limitations'

--- a/packages/cli/templates/js/package.json
+++ b/packages/cli/templates/js/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "check:types": "tsc --noEmit",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "0.0.1-beta.1"

--- a/packages/cli/templates/monorepo/package.json
+++ b/packages/cli/templates/monorepo/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "add-plugin": "npx @storyblok/field-plugin-cli@alpha add --dir \"./packages\" --structure monorepo",
+    "add-plugin": "npx @storyblok/field-plugin-cli@beta add --dir \"./packages\" --structure monorepo",
     "lint": "eslint --ext .js,.vue .",
     "format": "prettier . --write"
   },

--- a/packages/cli/templates/react/package.json
+++ b/packages/cli/templates/react/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "0.0.1-beta.1",

--- a/packages/cli/templates/vue2/package.json
+++ b/packages/cli/templates/vue2/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "0.0.1-beta.1",

--- a/packages/cli/templates/vue3/package.json
+++ b/packages/cli/templates/vue3/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@alpha deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "0.0.1-beta.1",


### PR DESCRIPTION
## What?

use `@beta` instead of `@alpha` with the cli 

## Why?

Users are currently misled to use the alpha version
