### PR TITLE
chore(template): provide empty component as placeholder

### DIFF
--- a/packages/cli/templates/react/README.md
+++ b/packages/cli/templates/react/README.md
@@ -42,4 +42,4 @@ yarn deploy --name $NAME --skipPrompts
 
 ## Clean up the boilerplate
 
-To start from a blank state, remove the example component `<FieldPluginExample />` from `src/App.tsx`.
+To start from a blank state, remove the example component `<FieldPluginExample />` from `src/App.tsx` with `<FieldPlugin />`.

--- a/packages/cli/templates/react/src/App.tsx
+++ b/packages/cli/templates/react/src/App.tsx
@@ -1,3 +1,4 @@
+import FieldPlugin from './components/FieldPlugin'
 import FieldPluginExample from './components/FieldPluginExample'
 import { FunctionComponent } from 'react'
 import { FieldPluginProvider } from './FieldPluginProvider'

--- a/packages/cli/templates/react/src/components/FieldPlugin.tsx
+++ b/packages/cli/templates/react/src/components/FieldPlugin.tsx
@@ -1,0 +1,10 @@
+import { FunctionComponent } from 'react'
+import { useFieldPlugin } from '../useFieldPlugin'
+
+const FieldPlugin: FunctionComponent = () => {
+  const plugin = useFieldPlugin()
+
+  return <pre>{JSON.stringify(plugin, null, 2)}</pre>
+}
+
+export default FieldPlugin

--- a/packages/cli/templates/vue2/README.md
+++ b/packages/cli/templates/vue2/README.md
@@ -36,4 +36,4 @@ yarn deploy --name $NAME --skipPrompts
 
 ## Clean up the boilerplate
 
-To start from a blank state, remove the example component `<FieldPluginExample />` from `src/App.vue`.
+To start from a blank state, remove the example component `<FieldPluginExample />` from `src/App.vue` with `<FieldPlugin />`.

--- a/packages/cli/templates/vue2/src/App.vue
+++ b/packages/cli/templates/vue2/src/App.vue
@@ -9,11 +9,13 @@
 
 <script>
 import FieldPluginProvider from './components/FieldPluginProvider.vue'
+import FieldPlugin from './components/FieldPlugin.vue'
 import FieldPluginExample from './components/FieldPluginExample/index.vue'
 
 export default {
   components: {
     FieldPluginProvider,
+    FieldPlugin,
     FieldPluginExample,
   },
 }

--- a/packages/cli/templates/vue2/src/components/FieldPlugin.vue
+++ b/packages/cli/templates/vue2/src/components/FieldPlugin.vue
@@ -1,0 +1,9 @@
+<template>
+  <pre>{{ JSON.stringify(plugin, null, 2) }}</pre>
+</template>
+
+<script>
+export default {
+  inject: ['plugin'],
+}
+</script>

--- a/packages/cli/templates/vue3/README.md
+++ b/packages/cli/templates/vue3/README.md
@@ -44,4 +44,4 @@ yarn deploy --name $NAME --skipPrompts
 
 ## Clean up the boilerplate
 
-To start from a blank state, remove the example component `<FieldPluginExample />` from `src/App.vue`.
+To start from a blank state, replace the example component `<FieldPluginExample />` from `src/App.vue` with `<FieldPlugin />`.

--- a/packages/cli/templates/vue3/src/App.vue
+++ b/packages/cli/templates/vue3/src/App.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import FieldPlugin from './components/FieldPlugin.vue'
 import FieldPluginExample from './components/FieldPluginExample/index.vue'
 import FieldPluginProvider from './components/FieldPluginProvider.vue'
 </script>

--- a/packages/cli/templates/vue3/src/components/FieldPlugin.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPlugin.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { useFieldPlugin } from '../useFieldPlugin'
+
+const plugin = useFieldPlugin()
+</script>
+
+<template>
+  <pre>
+    {{ JSON.stringify(plugin, null, 2) }}
+  </pre>
+</template>


### PR DESCRIPTION
## What?

Continuing on #211, this PR provides an empty `<FieldPlugin />` component so that users can easily replace the example component with it.
