### PR TITLE
fix(template): use scoped styles for FieldPluginProvider.vue

### DIFF
--- a/packages/cli/templates/vue2/src/components/FieldPluginProvider.vue
+++ b/packages/cli/templates/vue2/src/components/FieldPluginProvider.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full">
+  <div class="field-plugin-provider">
     <slot
       name="loading"
       v-if="plugin.type === 'loading'"
@@ -36,3 +36,8 @@ export default {
   },
 }
 </script>
+<style scoped>
+.field-plugin-provider {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
Issue: EXT-1728

## What?

Use scoped styles for `FieldPluginProvider.vue`.


## Why?

The templates use global styles which cause issues.

This one is caused when you remove the `/*Layout Styles*/` section in style.css. Because the `FieldPluginProvider.vue` has a div element at the root that uses the global style `w-full`,when you remove the layout styles, the app will not take up the full width.

The Vue 3 template does not have this excact issue, because in Vue 3, it is allowed to not have an element at the root.