### PR TITLE
feat(common): full viewport height in modal mode

### DIFF
--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -264,7 +264,7 @@ export const FieldPluginContainer: FunctionComponent = () => {
           >
             <FieldTypePreview
               src={iframeSrc}
-              height={`${height}px`}
+              height={height}
               isModal={isModalOpen}
               ref={fieldTypeIframe}
             />

--- a/packages/container/src/components/FieldTypePreview.tsx
+++ b/packages/container/src/components/FieldTypePreview.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
 } from '@mui/material'
 import { DisableShieldsNotification } from './DisableShieldsNotification'
+import { Property } from 'csstype'
 
 const FieldTypeModal: FunctionComponent<
   PropsWithChildren<{
@@ -59,6 +60,7 @@ const FieldTypeContainer: FunctionComponent<
           }
     }
     style={{
+      display: 'flex',
       margin: 'auto',
       width: props.isModal ? '90%' : '100%',
     }}
@@ -71,7 +73,7 @@ export const FieldTypePreview = forwardRef<
   HTMLIFrameElement,
   {
     src: string | undefined
-    height: string
+    height: Property.Height<string | number>
     isModal: boolean
     // Allows the iframe to be refreshed
     iframeKey?: number

--- a/packages/demo/src/components/App.tsx
+++ b/packages/demo/src/components/App.tsx
@@ -2,6 +2,10 @@ import { FunctionComponent } from 'react'
 import { CssBaseline, ThemeProvider } from '@mui/material'
 import { lightTheme } from '@storyblok/mui'
 import { FieldPluginDemo } from './FieldPluginDemo'
+import '@fontsource/roboto/300.css'
+import '@fontsource/roboto/400.css'
+import '@fontsource/roboto/500.css'
+import '@fontsource/roboto/700.css'
 
 export const App: FunctionComponent = () => (
   <ThemeProvider theme={lightTheme}>

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -1,13 +1,10 @@
 import { FunctionComponent } from 'react'
-import { Box, Divider, Paper, Stack, Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import { useFieldPlugin } from '../useFieldPlugin'
 import { LoadingIcon, SquareErrorIcon } from '@storyblok/mui'
 import { FieldPluginActions, FieldPluginData } from '@storyblok/field-plugin'
-import { ValueMutator } from './ValueMutator'
-import { ModalToggle } from './ModalToggle'
-import { AssetSelector } from './AssetSelector'
-import { ContextRequester } from './ContextRequester'
-import { UpdaterFunctionDemo } from './UpdaterFunctionDemo'
+import { ModalView } from './ModalView'
+import { NonModalView } from './NonModalView'
 
 export type PluginComponent = FunctionComponent<{
   data: FieldPluginData
@@ -38,17 +35,10 @@ export const FieldPluginDemo: FunctionComponent = () => {
     data,
     actions,
   }
-  return (
-    <Paper
-      sx={{ p: 3, border: (theme) => `1px solid ${theme.palette.divider}` }}
-    >
-      <Stack gap={6}>
-        <ValueMutator {...props} />
-        <UpdaterFunctionDemo {...props} />
-        <ModalToggle {...props} />
-        <AssetSelector {...props} />
-        <ContextRequester {...props} />
-      </Stack>
-    </Paper>
+
+  return props.data.isModalOpen ? (
+    <ModalView {...props} />
+  ) : (
+    <NonModalView {...props} />
   )
 }

--- a/packages/demo/src/components/ModalView.tsx
+++ b/packages/demo/src/components/ModalView.tsx
@@ -1,0 +1,32 @@
+import { Stack, styled, Typography } from '@mui/material'
+import { ModalToggle } from './ModalToggle'
+import { ValueMutator } from './ValueMutator'
+import { NumberStack } from './NumberStack'
+import { PluginComponent } from './FieldPluginDemo'
+
+const ScrollArea = styled(Stack)(({ theme }) => ({
+  overflow: 'auto',
+  flex: 1,
+  p: theme.spacing(4),
+  borderColor: theme.palette.divider,
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderRadius: theme.shape.borderRadius,
+}))
+
+export const ModalView: PluginComponent = (props) => (
+  <Stack
+    gap={6}
+    sx={{
+      height: '100vh',
+      justifyContent: 'space-between',
+    }}
+  >
+    <ModalToggle {...props} />
+    <ValueMutator {...props} />
+    <ScrollArea>
+      <NumberStack {...props} />
+    </ScrollArea>
+    <Typography>I am a footer that is positioned at the bottom!</Typography>
+  </Stack>
+)

--- a/packages/demo/src/components/NonModalView.tsx
+++ b/packages/demo/src/components/NonModalView.tsx
@@ -1,0 +1,22 @@
+import { Paper, Stack } from '@mui/material'
+import { ModalToggle } from './ModalToggle'
+import { ValueMutator } from './ValueMutator'
+import { NumberStack } from './NumberStack'
+import { UpdaterFunctionDemo } from './UpdaterFunctionDemo'
+import { AssetSelector } from './AssetSelector'
+import { ContextRequester } from './ContextRequester'
+import { PluginComponent } from './FieldPluginDemo'
+
+export const NonModalView: PluginComponent = (props) => (
+  <Paper>
+    <Stack gap={6}>
+      <ModalToggle {...props} />
+      <ValueMutator {...props} />
+      <UpdaterFunctionDemo {...props} />
+      <NumberStack {...props} />
+      <ModalToggle {...props} />
+      <AssetSelector {...props} />
+      <ContextRequester {...props} />
+    </Stack>
+  </Paper>
+)

--- a/packages/demo/src/components/NumberStack.tsx
+++ b/packages/demo/src/components/NumberStack.tsx
@@ -1,0 +1,13 @@
+import { Stack, Typography } from '@mui/material'
+import { zeros } from '../utils'
+import { PluginComponent } from './FieldPluginDemo'
+
+export const NumberStack: PluginComponent = (props) => (
+  <Stack>
+    {zeros(typeof props.data.content === 'number' ? props.data.content : 0).map(
+      (_, index) => (
+        <Typography key={index}>{index}</Typography>
+      ),
+    )}
+  </Stack>
+)

--- a/packages/demo/src/components/UpdaterFunctionDemo.tsx
+++ b/packages/demo/src/components/UpdaterFunctionDemo.tsx
@@ -12,10 +12,6 @@ export const UpdaterFunctionDemo: PluginComponent = (props) => {
       (content) => (typeof content === 'number' ? content : 0) + 1,
     )
   }
-  const label =
-    typeof data.content === 'undefined'
-      ? 'undefined'
-      : JSON.stringify(data.content)
 
   return (
     <Stack gap={2}>
@@ -24,7 +20,6 @@ export const UpdaterFunctionDemo: PluginComponent = (props) => {
         Increment the counter twice by calling <code>setContent</code> two times
         consecutively in between two renders.
       </Typography>
-      <Typography textAlign="center">{label}</Typography>
       <Button
         variant="outlined"
         color="secondary"

--- a/packages/demo/src/components/ValueMutator.tsx
+++ b/packages/demo/src/components/ValueMutator.tsx
@@ -8,6 +8,8 @@ export const ValueMutator: PluginComponent = (props) => {
     actions?.setContent(
       (typeof data.content === 'number' ? data.content : 0) + 1,
     )
+  const handleClickReset = () => actions?.setContent(0)
+
   const label =
     typeof data.content === 'undefined'
       ? 'undefined'
@@ -23,6 +25,13 @@ export const ValueMutator: PluginComponent = (props) => {
         onClick={handleClickIncrement}
       >
         Increment
+      </Button>
+      <Button
+        variant="outlined"
+        color="secondary"
+        onClick={handleClickReset}
+      >
+        Reset
       </Button>
     </Stack>
   )

--- a/packages/demo/src/utils/index.ts
+++ b/packages/demo/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './zeros'

--- a/packages/demo/src/utils/zeros.ts
+++ b/packages/demo/src/utils/zeros.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return,functional/immutable-data
+export const zeros = (n: number): 0[] => Array(n).fill(0)

--- a/packages/field-plugin/src/createFieldPlugin/createAutoResizer.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createAutoResizer.ts
@@ -6,14 +6,15 @@ import { heightChangeMessage } from '../messaging'
 export const createAutoResizer = (
   uid: string,
   postToContainer: (message: unknown) => void,
+  isEnabled: () => boolean,
 ) => {
   const handleResize = () => {
-    postToContainer(heightChangeMessage(uid, document.body.clientHeight))
+    if (!isEnabled()) {
+      return
+    }
+    postToContainer(heightChangeMessage(uid, `${document.body.clientHeight}px`))
   }
   const observer = new ResizeObserver(handleResize)
   observer.observe(document.body)
-  // window.addEventListener('resize', handleResize, false)
-  return () => {
-    observer.disconnect()
-  }
+  return () => observer.disconnect()
 }

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -46,7 +46,13 @@ export const createFieldPlugin: CreateFieldPlugin = (onUpdateState) => {
     window.parent.postMessage(message, origin)
   }
 
-  const cleanupAutoResizeSideEffects = createAutoResizer(uid, postToContainer)
+  let isModalOpen = false
+  const isAutoResizerEnabled = () => !isModalOpen
+  const cleanupAutoResizeSideEffects = createAutoResizer(
+    uid,
+    postToContainer,
+    isAutoResizerEnabled,
+  )
 
   const cleanupStyleSideEffects = disableDefaultStoryblokStyles()
 
@@ -54,6 +60,7 @@ export const createFieldPlugin: CreateFieldPlugin = (onUpdateState) => {
     uid,
     postToContainer,
     (data) => {
+      isModalOpen = data.isModalOpen
       onUpdateState({
         type: 'loaded',
         data,

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
@@ -2,6 +2,7 @@ import { createPluginActions } from './createPluginActions'
 import {
   AssetModalChangeMessage,
   GetContextMessage,
+  HeightChangeMessage,
   ModalChangeMessage,
   ValueChangeMessage,
 } from '../../messaging'
@@ -73,7 +74,7 @@ describe('createPluginActions', () => {
       } = createPluginActions(uid, postToContainer, onUpdateState)
       setModalOpen(false)
 
-      expect(postToContainer).toHaveBeenLastCalledWith(
+      expect(postToContainer).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'toggleModal',
           status: false,
@@ -81,11 +82,32 @@ describe('createPluginActions', () => {
       )
 
       setModalOpen(true)
-      expect(postToContainer).toHaveBeenLastCalledWith(
+      expect(postToContainer).toHaveBeenCalledWith(
         expect.objectContaining({
           event: 'toggleModal',
           status: true,
         } satisfies Partial<ModalChangeMessage>),
+      )
+    })
+    it('sends a height change message to the container when opened on modal mode', () => {
+      const { uid, postToContainer, onUpdateState } = mock()
+      const {
+        actions: { setModalOpen },
+      } = createPluginActions(uid, postToContainer, onUpdateState)
+      setModalOpen(false)
+
+      expect(postToContainer).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'heightChange',
+        } satisfies Partial<HeightChangeMessage>),
+      )
+
+      setModalOpen(true)
+      expect(postToContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'heightChange',
+          height: 'auto',
+        } satisfies Partial<HeightChangeMessage>),
       )
     })
   })

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -6,6 +6,7 @@ import {
   assetFromAssetSelectedMessage,
   assetModalChangeMessage,
   getContextMessage,
+  heightChangeMessage,
   modalChangeMessage,
   OnAssetSelectMessage,
   OnContextRequestMessage,
@@ -113,6 +114,9 @@ export const createPluginActions: CreatePluginActions = (
         const isModalOpen =
           typeof action === 'function' ? action(state.isModalOpen) : action
         postToContainer(modalChangeMessage(uid, isModalOpen))
+        if (isModalOpen) {
+          postToContainer(heightChangeMessage(uid, 'auto'))
+        }
         state = {
           ...state,
           isModalOpen,

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/HeightChangeMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/HeightChangeMessage.test.ts
@@ -33,20 +33,37 @@ describe('isHeightChangeMessage', () => {
         }),
       ).toEqual(false)
     })
-    test('that height is a number', () => {
-      expect(isHeightChangeMessage(stub)).toEqual(true)
-      expect(
-        isHeightChangeMessage({
-          ...stub,
-          height: '100vw',
-        }),
-      ).toEqual(false)
-      expect(
-        isHeightChangeMessage({
-          ...stub,
-          height: undefined,
-        }),
-      ).toEqual(false)
+    describe('height', () => {
+      it('can be a number', () => {
+        expect(
+          isHeightChangeMessage({
+            ...stub,
+            height: 123,
+          }),
+        ).toEqual(true)
+      })
+      it('can be a string in CSS units', () => {
+        expect(
+          isHeightChangeMessage({
+            ...stub,
+            height: 'auto',
+          }),
+        ).toEqual(true)
+        expect(
+          isHeightChangeMessage({
+            ...stub,
+            height: '100vw',
+          }),
+        ).toEqual(true)
+      })
+      it('is required', () => {
+        expect(
+          isHeightChangeMessage({
+            ...stub,
+            height: undefined,
+          }),
+        ).toEqual(false)
+      })
     })
   })
   describe('constructor', () => {

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/HeightChangeMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/HeightChangeMessage.ts
@@ -1,8 +1,9 @@
 import { hasKey } from '../../../utils'
 import { isMessageToContainer, MessageToContainer } from './MessageToContainer'
+import { Property } from 'csstype'
 
 export type HeightChangeMessage = MessageToContainer<'heightChange'> & {
-  height: number
+  height: Property.Height<string | number>
 }
 
 export const isHeightChangeMessage = (
@@ -11,11 +12,11 @@ export const isHeightChangeMessage = (
   isMessageToContainer(obj) &&
   obj.event === 'heightChange' &&
   hasKey(obj, 'height') &&
-  typeof obj.height === 'number'
+  (typeof obj.height === 'number' || typeof obj.height === 'string')
 
 export const heightChangeMessage = (
   uid: string,
-  height: number,
+  height: Property.Height<string | number>,
 ): HeightChangeMessage => ({
   action: 'plugin-changed',
   event: 'heightChange',


### PR DESCRIPTION
Field plugins will be using the full height of the modal window.

Issue: EXT-1806

When the field plugins enters modal mode, the height is set to `auto` and the `autoResizer` is disabled.

## Why?

In modal mode, the scroll should be visible within the field plugin, so that we can position elements at the bottom of the modal window. This is important for pagination, where the pagnation always should be visible, and should not be part of the scrolled content.

## How to test? (optional)

You must check out subtask/EXT-1795 from Storyfront and it in dev mode.

Then open up the demo app here. See how the height changes automatically in non-modal mode as you click on the increment button

While in modal mode, the height is fixed:

