### PR TITLE
feat(common): field plugin sdk data story language is missing in some cases

### DIFF
--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -26,14 +26,9 @@ import {
   AccordionDetails,
   AccordionSummary,
   Container,
-  Stack,
   Typography,
 } from '@mui/material'
-import {
-  CenteredContent,
-  ChevronDownIcon,
-  useNotifications,
-} from '@storyblok/mui'
+import { CenteredContent, useNotifications } from '@storyblok/mui'
 import { SchemaEditor } from './SchemaEditor'
 import { FieldTypePreview } from './FieldTypePreview'
 import { createContainerMessageListener } from '../dom/createContainerMessageListener'
@@ -47,7 +42,6 @@ import { usePluginParams } from './usePluginParams'
 const defaultUrl = 'http://localhost:8080'
 const initialStory: StoryData = {
   content: {},
-  lang: 'default',
 }
 const initialContent = ''
 const initialHeight = 300

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -8,6 +8,7 @@ import { ModalToggle } from './ModalToggle'
 import { AssetSelector } from './AssetSelector'
 import { ContextRequester } from './ContextRequester'
 import { UpdaterFunctionDemo } from './UpdaterFunctionDemo'
+import { LanguageView } from './LanguageView'
 
 export type PluginComponent = FunctionComponent<{
   data: FieldPluginData
@@ -48,6 +49,7 @@ export const FieldPluginDemo: FunctionComponent = () => {
         <ModalToggle {...props} />
         <AssetSelector {...props} />
         <ContextRequester {...props} />
+        <LanguageView {...props} />
       </Stack>
     </Paper>
   )

--- a/packages/demo/src/components/LanguageView.tsx
+++ b/packages/demo/src/components/LanguageView.tsx
@@ -1,0 +1,13 @@
+import { Stack, Typography } from '@mui/material'
+import { PluginComponent } from './FieldPluginDemo'
+
+export const LanguageView: PluginComponent = (props) => {
+  const { data } = props
+
+  return (
+    <Stack gap={2}>
+      <Typography variant="subtitle1">Language</Typography>
+      <Typography textAlign="center">{data.storyLang}</Typography>
+    </Stack>
+  )
+}

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
@@ -8,6 +8,7 @@ export type FieldPluginData = {
   content: unknown
   options: Record<string, string>
   spaceId: number | undefined
+  storyLang: string
   story: StoryData
   storyId: number | undefined
   blockUid: string | undefined

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -24,6 +24,7 @@ export const defaultState: FieldPluginData = {
   isModalOpen: false,
   content: undefined,
   options: {},
+  storyLang: 'default',
   story: { content: {} },
   blockUid: undefined,
   storyId: undefined,

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
@@ -5,12 +5,14 @@ import {
   StateChangedMessage,
 } from '../../messaging'
 
+//TODO: create a test
 export const partialPluginStateFromStateChangeMessage = (
   message: StateChangedMessage,
 ): Omit<FieldPluginData, 'isModalOpen'> => ({
   spaceId: message.spaceId ?? undefined,
   story: message.story ?? undefined,
   storyId: message.storyId ?? undefined,
+  storyLang: message.language === '' ? 'default' : message.language,
   blockUid: message.blockId ?? undefined,
   token: message.token ?? undefined,
   options: recordFromFieldPluginOptions(message.schema.options),

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.test.ts
@@ -65,6 +65,41 @@ describe('StateChangedMessage', () => {
       ).toEqual(false)
     })
   })
+
+  describe('the "language" property', () => {
+    it('is a string', () => {
+      expect(
+        isStateChangedMessage({
+          ...stub,
+          language: 'anything',
+        }),
+      ).toEqual(true)
+    })
+    it('is not undefined', () => {
+      expect(
+        isStateChangedMessage({
+          ...stub,
+          language: undefined,
+        }),
+      ).toEqual(false)
+    })
+    it('is not null', () => {
+      expect(
+        isStateChangedMessage({
+          ...stub,
+          language: null,
+        }),
+      ).toEqual(false)
+    })
+    it('is not a number', () => {
+      expect(
+        isStateChangedMessage({
+          ...stub,
+          language: 123,
+        }),
+      ).toEqual(false)
+    })
+  })
   describe('The "schema" property', () => {
     it('is required', () => {
       expect(

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.ts
@@ -25,6 +25,8 @@ export const isStateChangedMessage = (
   data: unknown,
 ): data is StateChangedMessage =>
   isMessageToPlugin(data) &&
+  hasKey(data, 'language') &&
+  typeof data.language === 'string' &&
   data.action === 'loaded' &&
   hasKey(data, 'schema') &&
   isFieldPluginSchema(data.schema) &&

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StoryData.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StoryData.test.ts
@@ -25,22 +25,6 @@ describe('StoryData', () => {
         expect(isStoryData({ content: null })).toEqual(false)
       })
     })
-    describe('the "lang" property', () => {
-      it('is optional', () => {
-        expect(isStoryData({ content: {} })).toEqual(true)
-        expect(isStoryData({ content: {}, lang: 'default' })).toEqual(true)
-      })
-      it('is is a string', () => {
-        expect(isStoryData({ content: {}, lang: 'default' })).toEqual(true)
-        expect(isStoryData({ content: {}, lang: 'en' })).toEqual(true)
-        expect(isStoryData({ content: {}, lang: 'english' })).toEqual(true)
-
-        expect(isStoryData({ content: {}, lang: 123 })).toEqual(false)
-        expect(isStoryData({ content: {}, lang: ['en'] })).toEqual(false)
-        expect(isStoryData({ content: {}, lang: { s: 1 } })).toEqual(false)
-        expect(isStoryData({ content: {}, lang: null })).toEqual(false)
-      })
-    })
     it('can have unknown properties', () => {
       expect(
         isStoryData({

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StoryData.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StoryData.ts
@@ -5,13 +5,10 @@ import { hasKey } from '../../../utils'
  */
 export type StoryData = {
   content: Record<string, unknown>
-  lang?: 'default' | string
 } & Record<string, unknown>
 
 export const isStoryData = (data: unknown): data is StoryData =>
   hasKey(data, 'content') &&
   typeof data.content === 'object' &&
   data.content !== null &&
-  !Array.isArray(data.content) &&
-  (!hasKey(data, 'lang') ||
-    (hasKey(data, 'lang') && typeof data.lang === 'string'))
+  !Array.isArray(data.content)


### PR DESCRIPTION
## What?
1. library: added storyLang and removed lang property from the story object
2. demo: added UI to display the language parameter
3. container: removed the hardcoded lang property

Removed lang parameter from story object and added the language as storyLang to the root object. 

## Why?

JIRA: [EXT-1801](https://storyblok.atlassian.net/browse/EXT-1801)

After looking into the get-context message delivered to the plugin, the team has found out that the story response does not include the lang property. This was the motivation to bring the language property back as it is passed via the loaded event. To make it more clear the decision was made to call it storyLang as the language is coherent with the language of the story and not the storyblok interface.


## How to test? 
1. Build field plugin demo
4. Open the field plugin inside Sandbox, Field Plugin Editor and Story

Observe the language parameter. 


[EXT-1801]: https://storyblok.atlassian.net/browse/EXT-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ