### PR TITLE
feat(cli): support different package managers

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -29,7 +29,7 @@ jobs:
       - run: git config --global user.name "Your Name"
       - run: yarn install
       - run: yarn workspace @storyblok/field-plugin-cli build
-      - run: npx field-plugin --dir=${{runner.temp}} --pluginName=temp-single-field-plugin --template=vue2 --structure=polyrepo
+      - run: npx field-plugin --dir=${{runner.temp}} --pluginName=temp-single-field-plugin --template=vue2 --structure=polyrepo --packageManager=npm
       - run: cd ${{runner.temp}}/temp-single-field-plugin && yarn build
   monorepo-cli-checks:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
       - run: git config --global user.name "Your Name"
       - run: yarn install
       - run: yarn workspace @storyblok/field-plugin-cli build
-      - run: npx field-plugin --dir=${{runner.temp}} --repoName=temp-monorepo-field-plugin --pluginName=test-plugin --template=vue2 --structure=monorepo
+      - run: npx field-plugin --dir=${{runner.temp}} --repoName=temp-monorepo-field-plugin --pluginName=test-plugin --template=vue2 --structure=monorepo --packageManager=npm
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
       - run: cd ${{runner.temp}}/temp-monorepo-field-plugin && yarn workspace test-plugin build

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -30,7 +30,7 @@ jobs:
       - run: yarn install
       - run: yarn workspace @storyblok/field-plugin-cli build
       - run: npx field-plugin --dir=${{runner.temp}} --pluginName=temp-single-field-plugin --template=vue2 --structure=polyrepo --packageManager=npm
-      - run: cd ${{runner.temp}}/temp-single-field-plugin && yarn build
+      - run: cd ${{runner.temp}}/temp-single-field-plugin && npm run build
   monorepo-cli-checks:
     runs-on: ubuntu-latest
     steps:
@@ -47,4 +47,4 @@ jobs:
       - run: npx field-plugin --dir=${{runner.temp}} --repoName=temp-monorepo-field-plugin --pluginName=test-plugin --template=vue2 --structure=monorepo --packageManager=npm
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
-      - run: cd ${{runner.temp}}/temp-monorepo-field-plugin && yarn workspace test-plugin build
+      - run: cd ${{runner.temp}}/temp-monorepo-field-plugin && npm run build --workspace=test-plugin

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,6 +37,7 @@ The `create` command allows a set of **optional** options for customization.
 ```bash
 --dir <value>         directory to create a repository into (default: `.`)
 --pluginName <value>  name of plugin (Lowercase alphanumeric and dash)
+--packageManager <value> package manager (choices: "npm", "yarn", "pnpm")
 --repoName <value>    name of repository, for monorepo (Lowercase alphanumeric and dash)
 --template <value>    name of template to use (choices: "vue2", "vue3", "react", "js")
 --structure <value>   setup structure (choices: "polyrepo", "monorepo")
@@ -50,13 +51,13 @@ The `create` command allows a set of **optional** options for customization.
 npx @storyblok/field-plugin-cli
 
 # Create a single field plugin with Vue 3 template inside a specific directory with a specific named
-npx @storyblok/field-plugin-cli create --dir=<PATH_TO_DIR> --pluginName=<FIELD_PLUGIN_NAME> --template=vue3 --structure=polyrepo
+npx @storyblok/field-plugin-cli create --dir=<PATH_TO_DIR> --pluginName=<FIELD_PLUGIN_NAME> --template=vue3 --structure=polyrepo --packageManager=npm
 
 # Create a single field plugin with React template inside a specific directory with a specific named
-npx @storyblok/field-plugin-cli create --dir=<PATH_TO_DIR> --pluginName=<FIELD_PLUGIN_NAME> --template=react --structure=polyrepo
+npx @storyblok/field-plugin-cli create --dir=<PATH_TO_DIR> --pluginName=<FIELD_PLUGIN_NAME> --template=react --structure=polyrepo --packageManager=npm
 
 # Create a monorepo with field plugin with a specific named inside a specific directory with Vue 2 template
-npx @storyblok/field-plugin-cli create --dir=<PATH_TO_DIR> --pluginName=<FIELD_PLUGIN_NAME> --template=vue3 --structure=monorepo
+npx @storyblok/field-plugin-cli create --dir=<PATH_TO_DIR> --pluginName=<FIELD_PLUGIN_NAME> --template=vue3 --structure=monorepo --packageManager=npm
 ```
 
 #### Structure
@@ -104,6 +105,7 @@ The options for the `add` command are the following:
 
 ```bash
 --template <value>  name of template to use (choices: "vue2", "vue3", "react", "js")
+--packageManager <value> package manager (choices: "npm", "yarn", "pnpm")
 --name <value>      name of plugin (Lowercase alphanumeric and dash)
 --dir <value>       directory to create a field plugin into (default: `.`)
 -h, --help          display help for command
@@ -116,10 +118,10 @@ The options for the `add` command are the following:
 npx @storyblok/field-plugin-cli add
 
 # Add field plugin with Vue 3 template to a project outside of the current directory
-npx @storyblok/field-plugin-cli add --name=<FIELD_PLUGIN_NAME> --template=vue3 --dir=<PATH_TO_DIR>
+npx @storyblok/field-plugin-cli add --name=<FIELD_PLUGIN_NAME> --template=vue3 --dir=<PATH_TO_DIR> --packageManager=npm
 
 # Add field plugin with React template to a project outside of the current directory
-npx @storyblok/field-plugin-cli add --name=<FIELD_PLUGIN_NAME> --template=react --dir=<PATH_TO_DIR>
+npx @storyblok/field-plugin-cli add --name=<FIELD_PLUGIN_NAME> --template=react --dir=<PATH_TO_DIR> --packageManager=npm
 ```
 
 [//]: # 'TBD Add GIF with interactive mode'

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 import { main } from './dist/main.cjs'
 
+console.log('💡 bin.js');
 main()

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
 import { main } from './dist/main.cjs'
 
-console.log('💡 bin.js');
 main()

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -14,7 +14,8 @@ import {
   checkIfSubDir,
   filterPathsToInclude,
   getInstallCommand,
-  getCommandByPackageManager,
+  getMonorepoCommandByPackageManager,
+  getPolyrepoCommandByPackageManager,
   isValidPackageManager,
   promptName,
   runCommand,
@@ -155,8 +156,7 @@ export const add: AddFunc = async (args) => {
     console.log(
       `    >`,
       green(
-        getCommandByPackageManager({
-          structure,
+        getPolyrepoCommandByPackageManager({
           packageManager,
           commandName: 'dev',
         }),
@@ -166,8 +166,7 @@ export const add: AddFunc = async (args) => {
     console.log(
       `    >`,
       green(
-        getCommandByPackageManager({
-          structure,
+        getMonorepoCommandByPackageManager({
           packageManager,
           commandName: 'dev',
           packageName,
@@ -182,8 +181,7 @@ export const add: AddFunc = async (args) => {
     console.log(
       `    >`,
       green(
-        getCommandByPackageManager({
-          structure,
+        getPolyrepoCommandByPackageManager({
           packageManager,
           commandName: 'deploy',
         }),
@@ -193,8 +191,7 @@ export const add: AddFunc = async (args) => {
     console.log(
       `    >`,
       green(
-        getCommandByPackageManager({
-          structure,
+        getMonorepoCommandByPackageManager({
           packageManager,
           commandName: 'deploy',
           packageName,

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -14,7 +14,7 @@ import {
   checkIfSubDir,
   filterPathsToInclude,
   getInstallCommand,
-  getNPMCommand,
+  getCommandByPackageManager,
   isValidPackageManager,
   promptName,
   runCommand,
@@ -154,13 +154,19 @@ export const add: AddFunc = async (args) => {
   if (structure === 'polyrepo') {
     console.log(
       `    >`,
-      green(getNPMCommand({ structure, packageManager, commandName: 'dev' })),
+      green(
+        getCommandByPackageManager({
+          structure,
+          packageManager,
+          commandName: 'dev',
+        }),
+      ),
     )
   } else if (structure === 'monorepo') {
     console.log(
       `    >`,
       green(
-        getNPMCommand({
+        getCommandByPackageManager({
           structure,
           packageManager,
           commandName: 'dev',
@@ -176,14 +182,18 @@ export const add: AddFunc = async (args) => {
     console.log(
       `    >`,
       green(
-        getNPMCommand({ structure, packageManager, commandName: 'deploy' }),
+        getCommandByPackageManager({
+          structure,
+          packageManager,
+          commandName: 'deploy',
+        }),
       ),
     )
   } else if (structure === 'monorepo') {
     console.log(
       `    >`,
       green(
-        getNPMCommand({
+        getCommandByPackageManager({
           structure,
           packageManager,
           commandName: 'deploy',

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -15,8 +15,10 @@ import {
   filterPathsToInclude,
   getInstallCommand,
   getNPMCommand,
+  isValidPackageManager,
   promptName,
   runCommand,
+  selectPackageManager,
 } from '../utils'
 import type { PackageManager } from './types'
 
@@ -54,7 +56,10 @@ const selectTemplate = async () => {
 }
 
 export const add: AddFunc = async (args) => {
-  const packageManager = args.packageManager
+  const packageManager = isValidPackageManager(args.packageManager)
+    ? args.packageManager
+    : await selectPackageManager()
+
   const structure = args.structure || 'polyrepo'
 
   console.log(bold(cyan('\nWelcome!')))
@@ -130,7 +135,7 @@ export const add: AddFunc = async (args) => {
     )
   }
 
-  const installCommand = getInstallCommand(args.packageManager)
+  const installCommand = getInstallCommand(packageManager)
   console.log(`\nRunning \`${installCommand}\`..\n`)
   console.log(
     (

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -13,9 +13,12 @@ import {
   betterPrompts,
   checkIfSubDir,
   filterPathsToInclude,
+  getInstallCommand,
+  getNPMCommand,
   promptName,
   runCommand,
 } from '../utils'
+import type { PackageManager } from './types'
 
 export type Template = 'vue2'
 
@@ -23,6 +26,7 @@ export type Structure = 'polyrepo' | 'monorepo'
 
 export type AddArgs = {
   dir: string
+  packageManager: PackageManager
   name?: string
   template?: Template
   structure?: Structure
@@ -50,6 +54,7 @@ const selectTemplate = async () => {
 }
 
 export const add: AddFunc = async (args) => {
+  const packageManager = args.packageManager
   const structure = args.structure || 'polyrepo'
 
   console.log(bold(cyan('\nWelcome!')))
@@ -125,10 +130,11 @@ export const add: AddFunc = async (args) => {
     )
   }
 
-  console.log(`\nRunning \`yarn install\`..\n`)
+  const installCommand = getInstallCommand(args.packageManager)
+  console.log(`\nRunning \`${installCommand}\`..\n`)
   console.log(
     (
-      await runCommand('yarn install', {
+      await runCommand(installCommand, {
         cwd: destPath,
       })
     ).stdout,
@@ -139,18 +145,47 @@ export const add: AddFunc = async (args) => {
   console.log(bold(cyan(`\n\nYour project \`${packageName}\` is ready 🚀\n`)))
   console.log(`- To run development mode run the following commands:`)
   console.log(`    >`, green(`cd ${relativePath}`))
+
   if (structure === 'polyrepo') {
-    console.log(`    >`, green(`yarn dev`))
+    console.log(
+      `    >`,
+      green(getNPMCommand({ structure, packageManager, commandName: 'dev' })),
+    )
   } else if (structure === 'monorepo') {
-    console.log(`    >`, green(`yarn workspace ${packageName} dev`))
+    console.log(
+      `    >`,
+      green(
+        getNPMCommand({
+          structure,
+          packageManager,
+          commandName: 'dev',
+          packageName,
+        }),
+      ),
+    )
   }
 
   console.log(`\n\n- To deploy the newly created field plugin to Storyblok:`)
   console.log(`    >`, green(`cd ${relativePath}`))
   if (structure === 'polyrepo') {
-    console.log(`    >`, green(`yarn deploy`))
+    console.log(
+      `    >`,
+      green(
+        getNPMCommand({ structure, packageManager, commandName: 'deploy' }),
+      ),
+    )
   } else if (structure === 'monorepo') {
-    console.log(`    >`, green(`yarn workspace ${packageName} deploy`))
+    console.log(
+      `    >`,
+      green(
+        getNPMCommand({
+          structure,
+          packageManager,
+          commandName: 'deploy',
+          packageName,
+        }),
+      ),
+    )
   }
   return { destPath }
 }

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -1,7 +1,11 @@
 import { createMonorepo } from './monorepo'
 import { createPolyrepo } from './polyrepo'
 import { Structure } from '../add'
-import { betterPrompts } from '../../utils'
+import {
+  betterPrompts,
+  isValidPackageManager,
+  selectPackageManager,
+} from '../../utils'
 import { CreateFunc, CreateArgs } from './types'
 import { PackageManager } from '../types'
 
@@ -33,44 +37,6 @@ const selectRepositoryStructure = async () => {
 
 const isValidStructure = (structure: string): structure is Structure => {
   return structure === 'monorepo' || structure === 'polyrepo'
-}
-
-const isValidPackageManager = (
-  packageManager?: string,
-): packageManager is PackageManager => {
-  return (
-    packageManager === 'npm' ||
-    packageManager === 'yarn' ||
-    packageManager === 'pnpm'
-  )
-}
-
-const selectPackageManager = async () => {
-  const { packageManager } = await betterPrompts<{
-    packageManager: PackageManager
-  }>([
-    {
-      type: 'select',
-      name: 'packageManager',
-      message: 'Which package manager do you use?',
-      initial: 'npm',
-      choices: [
-        {
-          title: 'npm',
-          value: 'npm',
-        },
-        {
-          title: 'yarn',
-          value: 'yarn',
-        },
-        {
-          title: 'pnpm',
-          value: 'pnpm',
-        },
-      ],
-    },
-  ])
-  return packageManager
 }
 
 export const create: CreateFunc = async (opts) => {

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -1,17 +1,11 @@
-import { createMonorepo, type CreateMonorepoArgs } from './monorepo'
-import { createPolyrepo, type CreatePolyrepoArgs } from './polyrepo'
+import { createMonorepo } from './monorepo'
+import { createPolyrepo } from './polyrepo'
 import { Structure } from '../add'
 import { betterPrompts } from '../../utils'
+import { CreateFunc, CreateArgs } from './types'
+import { PackageManager } from '../types'
 
-export type CreateArgs =
-  | ({
-      structure: 'monorepo'
-    } & CreateMonorepoArgs)
-  | ({
-      structure: 'polyrepo'
-    } & CreatePolyrepoArgs)
-
-export type CreateFunc = (args: CreateArgs) => Promise<void>
+export type { CreateArgs }
 
 const selectRepositoryStructure = async () => {
   const { structure } = await betterPrompts<{ structure: Structure }>([
@@ -41,15 +35,62 @@ const isValidStructure = (structure: string): structure is Structure => {
   return structure === 'monorepo' || structure === 'polyrepo'
 }
 
+const isValidPackageManager = (
+  packageManager?: string,
+): packageManager is PackageManager => {
+  return (
+    packageManager === 'npm' ||
+    packageManager === 'yarn' ||
+    packageManager === 'pnpm'
+  )
+}
+
+const selectPackageManager = async () => {
+  const { packageManager } = await betterPrompts<{
+    packageManager: PackageManager
+  }>([
+    {
+      type: 'select',
+      name: 'packageManager',
+      message: 'Which package manager do you use?',
+      initial: 'npm',
+      choices: [
+        {
+          title: 'npm',
+          value: 'npm',
+        },
+        {
+          title: 'yarn',
+          value: 'yarn',
+        },
+        {
+          title: 'pnpm',
+          value: 'pnpm',
+        },
+      ],
+    },
+  ])
+  return packageManager
+}
+
 export const create: CreateFunc = async (opts) => {
-  const { structure: structureParam, ...rest } = opts
+  const {
+    structure: structureParam,
+    packageManager: packageManagerParam,
+    ...rest
+  } = opts
+
+  const packageManager = isValidPackageManager(packageManagerParam)
+    ? packageManagerParam
+    : await selectPackageManager()
+
   const structure = isValidStructure(structureParam)
     ? structureParam
     : await selectRepositoryStructure()
 
   if (structure === 'polyrepo') {
-    await createPolyrepo(rest)
+    await createPolyrepo({ packageManager, ...rest })
   } else if (structure === 'monorepo') {
-    await createMonorepo(rest)
+    await createMonorepo({ packageManager, ...rest })
   }
 }

--- a/packages/cli/src/commands/create/monorepo.ts
+++ b/packages/cli/src/commands/create/monorepo.ts
@@ -86,7 +86,7 @@ export const createMonorepo: CreateMonorepoFunc = async ({
 
   if (packageManager === 'yarn' || packageManager === 'pnpm') {
     const json = JSON.parse(
-      readFileSync(resolve(templatePath, 'package.json')).toString(),
+      readFileSync(resolve(repoDir, 'package.json')).toString(),
     ) as Record<string, unknown> & { scripts: Record<string, string> }
 
     // eslint-disable-next-line functional/immutable-data
@@ -95,14 +95,14 @@ export const createMonorepo: CreateMonorepoFunc = async ({
     json['packageManager'] = packageManager === 'yarn' ? 'yarn@3.2.4' : 'pnpm'
 
     writeFileSync(
-      resolve(templatePath, 'package.json'),
+      resolve(repoDir, 'package.json'),
       JSON.stringify(json, null, 2),
     )
   }
 
   if (packageManager === 'pnpm') {
     writeFileSync(
-      resolve(templatePath, 'pnpm-workspace.yaml'),
+      resolve(repoDir, 'pnpm-workspace.yaml'),
       `packages:\n  - 'packages/*'\n`,
     )
   }

--- a/packages/cli/src/commands/create/polyrepo.ts
+++ b/packages/cli/src/commands/create/polyrepo.ts
@@ -1,21 +1,16 @@
-import { add, Template } from '../add'
+import { add } from '../add'
 import { initializeNewRepo } from '../../utils'
-
-export type CreatePolyrepoArgs = {
-  dir: string
-  pluginName?: string
-  template?: Template
-}
-
-type CreatePolyrepoFunc = (args: CreatePolyrepoArgs) => Promise<void>
+import { CreatePolyrepoFunc } from './types'
 
 export const createPolyrepo: CreatePolyrepoFunc = async ({
   dir,
+  packageManager,
   pluginName,
   template,
 }) => {
   const { destPath } = await add({
     dir,
+    packageManager,
     name: pluginName,
     template,
     structure: 'polyrepo',

--- a/packages/cli/src/commands/create/types.ts
+++ b/packages/cli/src/commands/create/types.ts
@@ -1,0 +1,31 @@
+import { Template } from '../add'
+import { PackageManager } from '../types'
+
+export type CreateArgs =
+  | ({
+      structure: 'monorepo'
+    } & CreateMonorepoArgs)
+  | ({
+      structure: 'polyrepo'
+    } & CreatePolyrepoArgs)
+
+export type CreateFunc = (args: CreateArgs) => Promise<void>
+
+export type CreateMonorepoArgs = {
+  dir: string
+  packageManager: PackageManager
+  repoName?: string
+  pluginName?: string
+  template?: Template
+}
+
+export type CreateMonorepoFunc = (args: CreateMonorepoArgs) => Promise<void>
+
+export type CreatePolyrepoArgs = {
+  dir: string
+  packageManager: PackageManager
+  pluginName?: string
+  template?: Template
+}
+
+export type CreatePolyrepoFunc = (args: CreatePolyrepoArgs) => Promise<void>

--- a/packages/cli/src/commands/types.ts
+++ b/packages/cli/src/commands/types.ts
@@ -1,0 +1,1 @@
+export type PackageManager = 'npm' | 'yarn' | 'pnpm'

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -14,6 +14,7 @@ import packageJson from './../package.json'
 const program = new Command()
 const templateOptions = TEMPLATES.map((template) => template.value)
 const structureOptions = ['polyrepo', 'monorepo']
+const packageManagerOptions = ['npm', 'yarn', 'pnpm']
 
 export const main = () => {
   program
@@ -31,6 +32,11 @@ export const main = () => {
         structureOptions,
       ),
     )
+    .addOption(
+      new Option('--packageManager <value>', 'package manager')
+        .choices(packageManagerOptions)
+        .default('npm'),
+    )
     .option(
       '--pluginName <value>',
       'name of plugin (Lowercase alphanumeric and dash)',
@@ -40,8 +46,7 @@ export const main = () => {
       '[Monorepo] name of repository (Lowercase alphanumeric and dash)',
     )
     .action(async function (this: Command) {
-      const opts = this.opts<CreateArgs>()
-      await create(opts)
+      await create(this.opts<CreateArgs>())
     })
 
   program
@@ -78,18 +83,7 @@ export const main = () => {
       ),
     )
     .action(async function (this: Command) {
-      const { dir, skipPrompts, name, token, output, dotEnvPath, scope } =
-        this.opts<DeployArgs>()
-
-      await deploy({
-        skipPrompts,
-        token,
-        name,
-        dir,
-        output,
-        dotEnvPath,
-        scope,
-      })
+      await deploy(this.opts<DeployArgs>())
     })
 
   program
@@ -110,10 +104,13 @@ export const main = () => {
         structureOptions,
       ),
     )
+    .addOption(
+      new Option('--packageManager <value>', 'package manager')
+        .choices(packageManagerOptions)
+        .default('npm'),
+    )
     .action(async function (this: Command) {
-      const { name, template, dir, structure } = this.opts<AddArgs>()
-
-      await add({ name, template, dir, structure })
+      await add(this.opts<AddArgs>())
     })
 
   program.parse(process.argv)

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -33,9 +33,9 @@ export const main = () => {
       ),
     )
     .addOption(
-      new Option('--packageManager <value>', 'package manager')
-        .choices(packageManagerOptions)
-        .default('npm'),
+      new Option('--packageManager <value>', 'package manager').choices(
+        packageManagerOptions,
+      ),
     )
     .option(
       '--pluginName <value>',
@@ -105,9 +105,9 @@ export const main = () => {
       ),
     )
     .addOption(
-      new Option('--packageManager <value>', 'package manager')
-        .choices(packageManagerOptions)
-        .default('npm'),
+      new Option('--packageManager <value>', 'package manager').choices(
+        packageManagerOptions,
+      ),
     )
     .action(async function (this: Command) {
       await add(this.opts<AddArgs>())

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -210,3 +210,41 @@ export const getNPMCommand = (args: GetNPMCommandArgs) => {
     }
   }
 }
+
+export const isValidPackageManager = (
+  packageManager?: string,
+): packageManager is PackageManager => {
+  return (
+    packageManager === 'npm' ||
+    packageManager === 'yarn' ||
+    packageManager === 'pnpm'
+  )
+}
+
+export const selectPackageManager = async () => {
+  const { packageManager } = await betterPrompts<{
+    packageManager: PackageManager
+  }>([
+    {
+      type: 'select',
+      name: 'packageManager',
+      message: 'Which package manager do you use?',
+      initial: 'npm',
+      choices: [
+        {
+          title: 'npm',
+          value: 'npm',
+        },
+        {
+          title: 'yarn',
+          value: 'yarn',
+        },
+        {
+          title: 'pnpm',
+          value: 'pnpm',
+        },
+      ],
+    },
+  ])
+  return packageManager
+}

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,8 +1,9 @@
 import dotenv from 'dotenv'
 import prompts from 'prompts'
 import { isAbsolute, relative, resolve } from 'path'
-import { existsSync, appendFileSync } from 'fs'
+import { existsSync, appendFileSync, readFileSync, writeFileSync } from 'fs'
 import { bold, cyan } from 'kleur/colors'
+import { PackageManager } from './commands/types'
 
 type RunCommandFunc = (
   command: string,
@@ -176,4 +177,36 @@ export const checkIfSubDir = (parent: string, dir: string) => {
   }
 
   return !relativePath.startsWith('..') && !isAbsolute(relativePath)
+}
+
+export const getInstallCommand = (packageManager: PackageManager) => {
+  return `${packageManager} install`
+}
+
+type GetNPMCommandArgs =
+  | {
+      commandName: string
+      packageManager: PackageManager
+      structure: 'polyrepo'
+    }
+  | {
+      commandName: string
+      packageManager: PackageManager
+      structure: 'monorepo'
+      packageName: string
+    }
+
+export const getNPMCommand = (args: GetNPMCommandArgs) => {
+  if (args.structure === 'polyrepo') {
+    return `${args.packageManager} run ${args.commandName}`
+  } else {
+    const { commandName, packageManager, packageName } = args
+    if (packageManager === 'yarn') {
+      return `yarn workspace ${packageName} ${commandName}`
+    } else if (packageManager === 'pnpm') {
+      return `pnpm -F ${packageName} run ${commandName}`
+    } else {
+      return `npm run ${commandName} --workspace=${packageName}`
+    }
+  }
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -229,7 +229,6 @@ export const selectPackageManager = async () => {
       type: 'select',
       name: 'packageManager',
       message: 'Which package manager do you use?',
-      initial: 'npm',
       choices: [
         {
           title: 'npm',

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -183,7 +183,7 @@ export const getInstallCommand = (packageManager: PackageManager) => {
   return `${packageManager} install`
 }
 
-type GetNPMCommandArgs =
+type GetCommandByPackageManagerArgs =
   | {
       commandName: string
       packageManager: PackageManager
@@ -196,7 +196,9 @@ type GetNPMCommandArgs =
       packageName: string
     }
 
-export const getNPMCommand = (args: GetNPMCommandArgs) => {
+export const getCommandByPackageManager = (
+  args: GetCommandByPackageManagerArgs,
+) => {
   if (args.structure === 'polyrepo') {
     return `${args.packageManager} run ${args.commandName}`
   } else {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -183,34 +183,26 @@ export const getInstallCommand = (packageManager: PackageManager) => {
   return `${packageManager} install`
 }
 
-type GetCommandByPackageManagerArgs =
-  | {
-      commandName: string
-      packageManager: PackageManager
-      structure: 'polyrepo'
-    }
-  | {
-      commandName: string
-      packageManager: PackageManager
-      structure: 'monorepo'
-      packageName: string
-    }
-
-export const getCommandByPackageManager = (
-  args: GetCommandByPackageManagerArgs,
-) => {
-  if (args.structure === 'polyrepo') {
-    return `${args.packageManager} run ${args.commandName}`
+export const getMonorepoCommandByPackageManager = (args: {
+  commandName: string
+  packageManager: PackageManager
+  packageName: string
+}) => {
+  const { commandName, packageManager, packageName } = args
+  if (packageManager === 'yarn') {
+    return `yarn workspace ${packageName} ${commandName}`
+  } else if (packageManager === 'pnpm') {
+    return `pnpm -F ${packageName} run ${commandName}`
   } else {
-    const { commandName, packageManager, packageName } = args
-    if (packageManager === 'yarn') {
-      return `yarn workspace ${packageName} ${commandName}`
-    } else if (packageManager === 'pnpm') {
-      return `pnpm -F ${packageName} run ${commandName}`
-    } else {
-      return `npm run ${commandName} --workspace=${packageName}`
-    }
+    return `npm run ${commandName} --workspace=${packageName}`
   }
+}
+
+export const getPolyrepoCommandByPackageManager = (args: {
+  commandName: string
+  packageManager: PackageManager
+}) => {
+  return `${args.packageManager} run ${args.commandName}`
 }
 
 export const isValidPackageManager = (

--- a/packages/cli/templates/js/README.md
+++ b/packages/cli/templates/js/README.md
@@ -7,7 +7,7 @@ This project was generated with `@storyblok/field-plugin-cli`.
 For development, run the application locally with
 
 ```shell
-yarn dev
+npm run dev
 ```
 
 and open the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/).
@@ -15,13 +15,13 @@ and open the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/).
 To build the project, run
 
 ```shell
-yarn build
+npm run build
 ```
 
 Deploy the field plugin with the CLI. Issue a [personal access token](https://app.storyblok.com/#/me/account?tab=token), rename `.env.local.example` to `.env.example`, open the file, set the value `STORYBLOK_PERSONAL_ACCESS_TOKEN`, and run
 
 ```shell
-yarn deploy
+npm run deploy
 ```
 
 ## Next Steps
@@ -31,7 +31,7 @@ Read more about field plugins [on GitHub](https://github.com/storyblok/field-plu
 Set up continuous integration with the [CLI](https://www.npmjs.com/package/@storyblok/field-plugin-cli). Define an environmental variable `STORYBLOK_PERSONAL_ACCESS_TOKEN`, and use the `--name` and `--skipPrompts` options as such:
 
 ```shell
-yarn deploy --name $NAME --skipPrompts
+npm run deploy --name $NAME --skipPrompts
 ```
 
 ## Clean up the boilerplate

--- a/packages/cli/templates/js/vite.config.ts
+++ b/packages/cli/templates/js/vite.config.ts
@@ -50,7 +50,7 @@ function printProd(): PluginOption {
       console.log(` 
   Deploy the plugin to production with:
   
-    ${green('yarn deploy')}
+    ${green('npm run deploy')}
       `)
     },
   }

--- a/packages/cli/templates/monorepo/package.json
+++ b/packages/cli/templates/monorepo/package.json
@@ -22,6 +22,5 @@
     "prettier": "2.8.0",
     "typescript": "4.6.4",
     "vite": "^4.2.2"
-  },
-  "packageManager": "yarn@3.2.4"
+  }
 }

--- a/packages/cli/templates/react/README.md
+++ b/packages/cli/templates/react/README.md
@@ -11,7 +11,7 @@ For those who prefer to work with JavaScript instead of TypeScript, they can ren
 For development, run the application locally with
 
 ```shell
-yarn dev
+npm run dev
 ```
 
 and open the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/).
@@ -19,13 +19,13 @@ and open the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/).
 To build the project, run
 
 ```shell
-yarn build
+npm run build
 ```
 
 Deploy the field plugin with the CLI. Issue a [personal access token](https://app.storyblok.com/#/me/account?tab=token), rename `.env.local.example` to `.env.example`, open the file, set the value `STORYBLOK_PERSONAL_ACCESS_TOKEN`, and run
 
 ```shell
-yarn deploy
+npm run deploy
 ```
 
 ## Next Steps
@@ -35,7 +35,7 @@ Read more about field plugins [on GitHub](https://github.com/storyblok/field-plu
 Set up continuous integration with the [CLI](https://www.npmjs.com/package/@storyblok/field-plugin-cli). Define an environmental variable `STORYBLOK_PERSONAL_ACCESS_TOKEN`, and use the `--name` and `--skipPrompts` options as such:
 
 ```shell
-yarn deploy --name $NAME --skipPrompts
+npm run deploy --name $NAME --skipPrompts
 ```
 
 [@storyblok/mui](https://www.npmjs.com/package/@storyblok/mui) contains a component library and theme for [MUI](https://mui.com/). To add it to this project, follow the instructions in the [readme](https://github.com/storyblok/mui).

--- a/packages/cli/templates/react/vite.config.ts
+++ b/packages/cli/templates/react/vite.config.ts
@@ -52,7 +52,7 @@ function printProd(): PluginOption {
       console.log(` 
   Deploy the plugin to production with:
   
-    ${green('yarn deploy')}
+    ${green('npm run deploy')}
       `)
     },
   }

--- a/packages/cli/templates/vue2/README.md
+++ b/packages/cli/templates/vue2/README.md
@@ -7,7 +7,7 @@ This project was created using Vue 2. It consists of a set of base functionaliti
 For development, run the application locally with
 
 ```shell
-yarn dev
+npm run dev
 ```
 
 and open the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/).
@@ -15,13 +15,13 @@ and open the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/).
 To build the project, run
 
 ```shell
-yarn build
+npm run build
 ```
 
 Deploy the field plugin with the CLI. Issue a [personal access token](https://app.storyblok.com/#/me/account?tab=token), rename `.env.local.example` to `.env.example`, open the file, set the value `STORYBLOK_PERSONAL_ACCESS_TOKEN`, and run
 
 ```shell
-yarn deploy
+npm run deploy
 ```
 
 ## Next Steps
@@ -31,7 +31,7 @@ Read more about field plugins [on GitHub](https://github.com/storyblok/field-plu
 Set up continuous integration with the [CLI](https://www.npmjs.com/package/@storyblok/field-plugin-cli). Define an environmental variable `STORYBLOK_PERSONAL_ACCESS_TOKEN`, and use the `--name` and `--skipPrompts` options as such:
 
 ```shell
-yarn deploy --name $NAME --skipPrompts
+npm run deploy --name $NAME --skipPrompts
 ```
 
 ## Clean up the boilerplate

--- a/packages/cli/templates/vue2/vite.config.ts
+++ b/packages/cli/templates/vue2/vite.config.ts
@@ -58,7 +58,7 @@ function printProd(): PluginOption {
       console.log(` 
   Deploy the plugin to production with:
   
-    ${green('yarn deploy')}
+    ${green('npm run deploy')}
       `)
     },
   }

--- a/packages/cli/templates/vue3/README.md
+++ b/packages/cli/templates/vue3/README.md
@@ -13,7 +13,7 @@ If you prefer to use the Options API, you can refer to [the Vue 2 template](http
 For development, run the application locally with
 
 ```shell
-yarn dev
+npm run dev
 ```
 
 and open the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/).
@@ -21,13 +21,13 @@ and open the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/).
 To build the project, run
 
 ```shell
-yarn build
+npm run build
 ```
 
 Deploy the field plugin with the CLI. Issue a [personal access token](https://app.storyblok.com/#/me/account?tab=token), rename `.env.local.example` to `.env.example`, open the file, set the value `STORYBLOK_PERSONAL_ACCESS_TOKEN`, and run
 
 ```shell
-yarn deploy
+npm run deploy
 ```
 
 ## Next Steps
@@ -37,7 +37,7 @@ Read more about field plugins [on GitHub](https://github.com/storyblok/field-plu
 Set up continuous integration with the [CLI](https://www.npmjs.com/package/@storyblok/field-plugin-cli). Define an environmental variable `STORYBLOK_PERSONAL_ACCESS_TOKEN`, and use the `--name` and `--skipPrompts` options as such:
 
 ```shell
-yarn deploy --name $NAME --skipPrompts
+npm run deploy --name $NAME --skipPrompts
 ```
 
 [@storyblok/design-system](https://www.npmjs.com/package/@storyblok/design-system) is Storyblok's component library for Vue. To add it to this project, follow the instructions in the [readme](https://www.npmjs.com/package/@storyblok/design-system).

--- a/packages/cli/templates/vue3/vite.config.ts
+++ b/packages/cli/templates/vue3/vite.config.ts
@@ -52,7 +52,7 @@ function printProd(): PluginOption {
       console.log(` 
   Deploy the plugin to production with:
   
-    ${green('yarn deploy')}
+    ${green('npm run deploy')}
       `)
     },
   }


### PR DESCRIPTION
## What?

This PR adds support for npm and pnpm.

* It adds `--packageManager` option to `create` and `add` command.
* In case of monorepo with yarn, it adds `"packageManager": "yarn@3.2.4"` to `package.json`.
* In case of monorepo with pnpm,
  * it adds `"packageManager": "pnpm"` to `package.json`.
  * it adds `pnpm-workspace.yaml` file as well.


## Why?

JIRA: EXT-1063

We initially started this project with yarn and yarn workspace. However, we'd like to support those using npm and pnpm. And both of them support workspaces.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->