### PR TITLE
chore(cli): keep latest tag on npm up to date

### DIFF
--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -24,3 +24,9 @@ jobs:
         run: cd packages/cli && npm publish --access public --tag beta
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH}}
+      - name: Tag latest to the published version
+        run: |
+          PACKAGE_VERSION=$(cd packages/cli && npm pkg get version --workspaces=false | tr -d \")
+          cd packages/cli && npm dist-tag add "@storyblok/field-plugin@${PACKAGE_VERSION}" latest
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH}}


### PR DESCRIPTION
## What?

People forget `@latest` when running npx `@storyblok/field-plugin-cli`, and they end up getting an old version of the CLI.

We can use `npm dist-tag` command to keep `@beta` and `@latest` the same.

ref: https://www.grzegorowski.com/what-are-npm-dist-tags-how-to-use-them

## Why?

JIRA: EXT-1805

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->