### PR TITLE
fix(template): remove non-existing properties correctly in vue 3 template

### DIFF
--- a/packages/helper-vue3/src/FieldPluginProvider.vue
+++ b/packages/helper-vue3/src/FieldPluginProvider.vue
@@ -10,6 +10,22 @@ import { convertToRaw } from '../utils'
 const plugin = reactive<FieldPluginResponse>({
   type: 'loading',
 })
+
+const updateObjectWithoutChangingReference = (
+  originalObject: Record<string, unknown>,
+  newObject: Record<string, unknown>,
+) => {
+  // Delete keys that do not exist anymore
+  Object.keys(originalObject).forEach((key) => {
+    if (newObject[key] === undefined) {
+      delete originalObject[key]
+    }
+  })
+  // Update the original object with the new one
+  // @ts-ignore not sure how to solve this
+  Object.assign(originalObject, newObject)
+}
+
 createFieldPlugin((newState) => {
   // Instead of replacing `plugin.data` which loses the reactive reference,
   // we're assigning each property into `plugin.data`.
@@ -25,8 +41,10 @@ createFieldPlugin((newState) => {
     const keys = Object.keys(newState.data) as Array<keyof FieldPluginData>
     keys.forEach((key) => {
       if (typeof plugin.data[key] === 'object') {
-        // @ts-ignore not sure how to solve this
-        Object.assign(plugin.data[key], newState.data[key])
+        updateObjectWithoutChangingReference(
+          plugin.data[key] as Record<string, unknown>,
+          newState.data[key] as Record<string, unknown>,
+        )
       } else {
         // @ts-ignore not sure how to solve this
         plugin.data[key] = newState.data[key]


### PR DESCRIPTION
## What?

This PR removes properties that no longer exist in `FieldPluginProvider` of the vue 3 template.

## Why?

JIRA: EXT-1817

The Jira ticket mentions the changing `options`, but actually the same problem happened to `plugin.data.content` too.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->