### PR TITLE
fix(cli): remove unnecessary install command in monorepo and provide docs

### DIFF
--- a/packages/cli/src/commands/create/monorepo.ts
+++ b/packages/cli/src/commands/create/monorepo.ts
@@ -72,6 +72,12 @@ const specifyPackageManager = ({
   }
 }
 
+const MONOREPO_DOCS: Record<PackageManager, string> = {
+  npm: 'https://docs.npmjs.com/cli/v7/using-npm/workspaces',
+  yarn: 'https://yarnpkg.com/features/workspaces',
+  pnpm: 'https://pnpm.io/workspaces',
+}
+
 export const createMonorepo: CreateMonorepoFunc = async ({
   dir,
   packageManager,
@@ -118,10 +124,6 @@ export const createMonorepo: CreateMonorepoFunc = async ({
     )
   }
 
-  const installCommand = getInstallCommand(packageManager)
-  console.log(bold(cyan(`[info] Running \`${installCommand}\`...`)))
-  await runCommand(installCommand, { cwd: repoDir })
-
   console.log(bold(cyan('[info] Creating the first field-plugin...')))
   await add({
     dir: `${repoDir}/packages`,
@@ -132,4 +134,7 @@ export const createMonorepo: CreateMonorepoFunc = async ({
   })
   unlinkSync(`${repoDir}/packages/.gitkeep`)
   await initializeNewRepo({ dir: repoDir })
+
+  console.log('\n\n- To learn more about monorepo:')
+  console.log(`    > ${MONOREPO_DOCS[packageManager]}`)
 }

--- a/packages/cli/src/commands/create/monorepo.ts
+++ b/packages/cli/src/commands/create/monorepo.ts
@@ -12,9 +12,7 @@ import { MONOREPO_TEMPLATE_PATH } from '../../../config'
 import {
   betterPrompts,
   filterPathsToInclude,
-  getInstallCommand,
   initializeNewRepo,
-  runCommand,
 } from '../../utils'
 import { add } from '../add'
 import walk from 'walkdir'


### PR DESCRIPTION
## What?

This PR removes unnecessary `npm install`, `yarn install`, or `pnpm install` during the monorepo creation process, because the install command is called right after adding an actual field plugin package.

It also provides a link to doc regarding monorepo.

## Why?

JIRA: EXT-1818


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->