### PR TITLE
feat(cli): deploy command including org scope

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -312,7 +312,7 @@ const selectApiScope = async (token: string): Promise<Scope> => {
   ) {
     console.error(
       red('[ERROR]'),
-      `The token appears to be invalid as it does not have access to either My Plugins or the plugins on the Partner Portal.`,
+      `The token appears to be invalid as it does not have access to either My Plugins, the plugins on the Partner Portal or the Organization plugins.`,
     )
     process.exit(1)
   }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -115,9 +115,18 @@ export const deploy: DeployFunc = async ({
     console.log(
       `  > https://app.storyblok.com/#/partner/fields/${fieldPluginId}`,
     )
-  } else {
+  }
+
+  if (apiScope === 'my-plugins') {
     console.log(`  > https://app.storyblok.com/#/me/plugins/${fieldPluginId}`)
   }
+
+  if (apiScope === 'organization') {
+    console.log(
+      `  > https://app.storyblok.com/#/me/org/fields/${fieldPluginId}`,
+    )
+  }
+
   console.log(
     'You can also find it in "My account > My Plugins" at the bottom of the sidebar.',
   )
@@ -291,7 +300,16 @@ const selectApiScope = async (token: string): Promise<Scope> => {
     scope: 'partner-portal',
   }).isAuthenticated()
 
-  if (!accessibleToMyPlugins && !accessibleToPartnerPortal) {
+  const accessibleToOrganizationPortal = await StoryblokClient({
+    token,
+    scope: 'organization',
+  }).isAuthenticated()
+
+  if (
+    !accessibleToMyPlugins &&
+    !accessibleToPartnerPortal &&
+    !accessibleToOrganizationPortal
+  ) {
     console.error(
       red('[ERROR]'),
       `The token appears to be invalid as it does not have access to either My Plugins or the plugins on the Partner Portal.`,
@@ -312,6 +330,10 @@ const selectApiScope = async (token: string): Promise<Scope> => {
         accessibleToPartnerPortal && {
           title: 'Partner Portal',
           value: 'partner-portal',
+        },
+        accessibleToOrganizationPortal && {
+          title: 'Organization',
+          value: 'organization',
         },
       ].filter(Boolean) as Choice[],
     },

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -15,6 +15,7 @@ const program = new Command()
 const templateOptions = TEMPLATES.map((template) => template.value)
 const structureOptions = ['standalone', 'monorepo']
 const packageManagerOptions = ['npm', 'yarn', 'pnpm']
+const deployScopeOptions = ['my-plugins', 'partner-portal', 'organization']
 
 export const main = () => {
   program
@@ -79,8 +80,8 @@ export const main = () => {
     .addOption(
       new Option(
         '--scope <value>',
-        `where to deploy the field plugin ('my-plugins' | 'partner-portal')`,
-      ),
+        `where to deploy the field plugin ('my-plugins' | 'partner-portal' | 'organization')`,
+      ).choices(deployScopeOptions),
     )
     .action(async function (this: Command) {
       await deploy(this.opts<DeployArgs>())

--- a/packages/cli/src/storyblok/storyblok-client.ts
+++ b/packages/cli/src/storyblok/storyblok-client.ts
@@ -3,7 +3,7 @@ import type { Response } from 'node-fetch'
 
 export type FieldType = { id: number; name: string; body: string }
 
-export type Scope = 'my-plugins' | 'partner-portal'
+export type Scope = 'my-plugins' | 'partner-portal' | 'organization'
 
 type IsAuthenticatedFunc = () => Promise<boolean>
 
@@ -32,10 +32,7 @@ type StoryblokClientFunc = (params: { token: string; scope: Scope }) => {
 }
 
 export const StoryblokClient: StoryblokClientFunc = ({ token, scope }) => {
-  const FIELD_TYPES_API_ENDPOINT =
-    scope === 'partner-portal'
-      ? 'https://mapi.storyblok.com/v1/partner_field_types/'
-      : 'https://mapi.storyblok.com/v1/field_types/'
+  const FIELD_TYPES_API_ENDPOINT = getFieldPluginAPIEndpoint(scope)
 
   const headers = {
     Authorization: token ?? '',
@@ -145,4 +142,15 @@ const handleErrorIfExists = (
     }
     process.exit(1)
   }
+}
+
+const getFieldPluginAPIEndpoint = (scope: Scope) => {
+  if (scope === 'partner-portal') {
+    return 'https://mapi.storyblok.com/v1/partner_field_types/'
+  }
+  if (scope === 'organization') {
+    return 'https://app.storyblok.com/v1/org_field_types/'
+  }
+
+  return 'https://mapi.storyblok.com/v1/field_types/'
 }


### PR DESCRIPTION
## What?
Since past 2 weeks a new feature has been added to the product where organizations are able to create their own field plugins. For this new feature a new API endpoint has been added so we need to consider it inside our CLI to give the user the option to deploy to an organisation. 

## Why?

[JIRA: EXT-1849](https://storyblok.atlassian.net/browse/EXT-1849)


## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->