### PR TITLE
feat(lib): typed content

### DIFF
--- a/packages/demo/src/components/App.tsx
+++ b/packages/demo/src/components/App.tsx
@@ -2,10 +2,13 @@ import { FunctionComponent } from 'react'
 import { CssBaseline, ThemeProvider } from '@mui/material'
 import { lightTheme } from '@storyblok/mui'
 import { FieldPluginDemo } from './FieldPluginDemo'
+import { FieldPluginProvider } from './context'
 
 export const App: FunctionComponent = () => (
-  <ThemeProvider theme={lightTheme}>
-    <CssBaseline />
-    <FieldPluginDemo />
-  </ThemeProvider>
+  <FieldPluginProvider>
+    <ThemeProvider theme={lightTheme}>
+      <CssBaseline />
+      <FieldPluginDemo />
+    </ThemeProvider>
+  </FieldPluginProvider>
 )

--- a/packages/demo/src/components/App.tsx
+++ b/packages/demo/src/components/App.tsx
@@ -2,13 +2,10 @@ import { FunctionComponent } from 'react'
 import { CssBaseline, ThemeProvider } from '@mui/material'
 import { lightTheme } from '@storyblok/mui'
 import { FieldPluginDemo } from './FieldPluginDemo'
-import { FieldPluginProvider } from './context'
 
 export const App: FunctionComponent = () => (
-  <FieldPluginProvider>
-    <ThemeProvider theme={lightTheme}>
-      <CssBaseline />
-      <FieldPluginDemo />
-    </ThemeProvider>
-  </FieldPluginProvider>
+  <ThemeProvider theme={lightTheme}>
+    <CssBaseline />
+    <FieldPluginDemo />
+  </ThemeProvider>
 )

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -8,7 +8,8 @@ import { AssetSelector } from './AssetSelector'
 import { ContextRequester } from './ContextRequester'
 import { UpdaterFunctionDemo } from './UpdaterFunctionDemo'
 import { LanguageView } from './LanguageView'
-import { useFieldPlugin, Content } from './context'
+import { parseContent, Content } from './context'
+import { useFieldPlugin } from '../useFieldPlugin'
 
 export type PluginComponent = FunctionComponent<{
   data: FieldPluginData<Content>
@@ -16,7 +17,9 @@ export type PluginComponent = FunctionComponent<{
 }>
 
 export const FieldPluginDemo: FunctionComponent = () => {
-  const { type, data, actions } = useFieldPlugin<Content>()
+  const { type, data, actions } = useFieldPlugin<Content>({
+    parseContent,
+  })
 
   if (type === 'loading') {
     return (

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'react'
 import { Box, Divider, Paper, Stack, Typography } from '@mui/material'
-import { useFieldPlugin } from '../useFieldPlugin'
 import { LoadingIcon, SquareErrorIcon } from '@storyblok/mui'
 import { FieldPluginActions, FieldPluginData } from '@storyblok/field-plugin'
 import { ValueMutator } from './ValueMutator'
@@ -9,14 +8,15 @@ import { AssetSelector } from './AssetSelector'
 import { ContextRequester } from './ContextRequester'
 import { UpdaterFunctionDemo } from './UpdaterFunctionDemo'
 import { LanguageView } from './LanguageView'
+import { useFieldPlugin, Content } from './context'
 
 export type PluginComponent = FunctionComponent<{
-  data: FieldPluginData
-  actions: FieldPluginActions
+  data: FieldPluginData<Content>
+  actions: FieldPluginActions<Content>
 }>
 
 export const FieldPluginDemo: FunctionComponent = () => {
-  const { type, data, actions } = useFieldPlugin()
+  const { type, data, actions } = useFieldPlugin<Content>()
 
   if (type === 'loading') {
     return (

--- a/packages/demo/src/components/ModalToggle.tsx
+++ b/packages/demo/src/components/ModalToggle.tsx
@@ -9,7 +9,7 @@ export const ModalToggle: PluginComponent = (props) => {
       <FormControlLabel
         control={<Switch defaultChecked />}
         checked={data.isModalOpen}
-        onChange={() => actions.setModalOpen(!data.isModalOpen)}
+        onChange={() => actions.setModalOpen((isOpen) => !isOpen)}
         label="Modal"
         sx={{
           justifyContent: 'center',

--- a/packages/demo/src/components/UpdaterFunctionDemo.tsx
+++ b/packages/demo/src/components/UpdaterFunctionDemo.tsx
@@ -1,37 +1,32 @@
-import { Button, Stack, Typography } from '@mui/material'
+import { Button, Stack, Tooltip } from '@mui/material'
 import { PluginComponent } from './FieldPluginDemo'
 
 export const UpdaterFunctionDemo: PluginComponent = (props) => {
-  const { data, actions } = props
+  const { actions } = props
 
   const handleClickIncrement = () => {
-    actions?.setContent(
-      (content) => (typeof content === 'number' ? content : 0) + 1,
-    )
-    actions?.setContent(
-      (content) => (typeof content === 'number' ? content : 0) + 1,
-    )
+    actions.setContent((content) => content + 1)
+    actions.setContent((content) => content + 1)
   }
-  const label =
-    typeof data.content === 'undefined'
-      ? 'undefined'
-      : JSON.stringify(data.content)
 
   return (
     <Stack gap={2}>
-      <Typography variant="subtitle1">Field Value</Typography>
-      <Typography>
-        Increment the counter twice by calling <code>setContent</code> two times
-        consecutively in between two renders.
-      </Typography>
-      <Typography textAlign="center">{label}</Typography>
-      <Button
-        variant="outlined"
-        color="secondary"
-        onClick={handleClickIncrement}
+      <Tooltip
+        title={
+          <>
+            Increment the counter twice by calling <code>setContent</code> two
+            times consecutively in between two renders.
+          </>
+        }
       >
-        Increment twice
-      </Button>
+        <Button
+          variant="outlined"
+          color="secondary"
+          onClick={handleClickIncrement}
+        >
+          Increment twice
+        </Button>
+      </Tooltip>
     </Stack>
   )
 }

--- a/packages/demo/src/components/ValueMutator.tsx
+++ b/packages/demo/src/components/ValueMutator.tsx
@@ -5,18 +5,12 @@ export const ValueMutator: PluginComponent = (props) => {
   const { data, actions } = props
 
   const handleClickIncrement = () =>
-    actions?.setContent(
-      (typeof data.content === 'number' ? data.content : 0) + 1,
-    )
-  const label =
-    typeof data.content === 'undefined'
-      ? 'undefined'
-      : JSON.stringify(data.content)
+    actions.setContent((content) => content + 1)
 
   return (
     <Stack gap={2}>
       <Typography variant="subtitle1">Field Value</Typography>
-      <Typography textAlign="center">{label}</Typography>
+      <Typography textAlign="center">{data.content}</Typography>
       <Button
         variant="outlined"
         color="secondary"

--- a/packages/demo/src/components/context.ts
+++ b/packages/demo/src/components/context.ts
@@ -1,8 +1,3 @@
-import { createFieldPluginContext } from '@storyblok/field-plugin/react'
-
 export type Content = number
-const parseContent = (content: unknown): Content =>
+export const parseContent = (content: unknown): Content =>
   typeof content === 'number' ? content : 0
-
-export const { FieldPluginProvider, useFieldPlugin } =
-  createFieldPluginContext(parseContent)

--- a/packages/demo/src/components/context.ts
+++ b/packages/demo/src/components/context.ts
@@ -1,0 +1,8 @@
+import { createFieldPluginContext } from '@storyblok/field-plugin/react'
+
+export type Content = number
+const parseContent = (content: unknown): Content =>
+  typeof content === 'number' ? content : 0
+
+export const { FieldPluginProvider, useFieldPlugin } =
+  createFieldPluginContext(parseContent)

--- a/packages/demo/src/useFieldPlugin.ts
+++ b/packages/demo/src/useFieldPlugin.ts
@@ -3,13 +3,16 @@ import { useEffect, useState } from 'react'
 
 type UseFieldPlugin = () => FieldPluginResponse
 
+const parseContent = (content: unknown) =>
+  typeof content === 'number' ? content : 0
+
 export const useFieldPlugin: UseFieldPlugin = () => {
   const [state, setState] = useState<FieldPluginResponse>(() => ({
     type: 'loading',
   }))
 
   useEffect(() => {
-    return createFieldPlugin(setState)
+    return createFieldPlugin(setState, parseContent)
   }, [])
 
   return state

--- a/packages/demo/src/useFieldPlugin.ts
+++ b/packages/demo/src/useFieldPlugin.ts
@@ -1,22 +1,24 @@
-import { createFieldPlugin, FieldPluginResponse } from '@storyblok/field-plugin'
+import {
+  createFieldPlugin,
+  FieldPluginOptions,
+  FieldPluginResponse,
+} from '@storyblok/field-plugin'
 import { useEffect, useState } from 'react'
 
-type UseFieldPlugin = () => FieldPluginResponse
-
-type Parser<Content> = (content: unknown) => Content
-
-type Content = number
-const parseContent: Parser<Content> = (content) =>
-  typeof content === 'number' ? content : 0
-
-export const useFieldPlugin: UseFieldPlugin = () => {
-  const [state, setState] = useState<FieldPluginResponse>(() => ({
+export const useFieldPlugin = <Content>(
+  options: FieldPluginOptions<Content>,
+): FieldPluginResponse<Content> => {
+  const [state, setState] = useState<FieldPluginResponse<Content>>(() => ({
     type: 'loading',
   }))
 
-  useEffect(() => {
-    return createFieldPlugin(setState, parseContent)
-  }, [])
+  useEffect(
+    () =>
+      createFieldPlugin<Content>(setState, {
+        parseContent: options.parseContent,
+      }),
+    [options.parseContent],
+  )
 
   return state
 }

--- a/packages/demo/src/useFieldPlugin.ts
+++ b/packages/demo/src/useFieldPlugin.ts
@@ -3,7 +3,10 @@ import { useEffect, useState } from 'react'
 
 type UseFieldPlugin = () => FieldPluginResponse
 
-const parseContent = (content: unknown) =>
+type Parser<Content> = (content: unknown) => Content
+
+type Content = number
+const parseContent: Parser<Content> = (content) =>
   typeof content === 'number' ? content : 0
 
 export const useFieldPlugin: UseFieldPlugin = () => {

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
@@ -1,13 +1,15 @@
 import { Asset } from '../messaging'
 
 export type SetStateAction<T> = T | ((value: T) => T)
-export type SetContent = <C>(setContentAction: SetStateAction<C>) => void
+export type SetContent<Content> = (
+  setContentAction: SetStateAction<Content>,
+) => void
 export type SetModalOpen = (setModalOpenAction: SetStateAction<boolean>) => void
 export type RequestContext = () => void
 export type SelectAsset = () => Promise<Asset>
 
-export type FieldPluginActions = {
-  setContent: SetContent
+export type FieldPluginActions<Content = unknown> = {
+  setContent: SetContent<Content>
   setModalOpen: SetModalOpen
   requestContext: RequestContext
   selectAsset: SelectAsset

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
@@ -3,9 +3,9 @@
  */
 import { StoryData } from '../messaging'
 
-export type FieldPluginData = {
+export type FieldPluginData<Content = unknown> = {
   isModalOpen: boolean
-  content: unknown
+  content: Content
   options: Record<string, string>
   spaceId: number | undefined
   storyLang: string

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
@@ -1,7 +1,7 @@
 import { FieldPluginData } from './FieldPluginData'
 import { FieldPluginActions } from './FieldPluginActions'
 
-export type FieldPluginResponse =
+export type FieldPluginResponse<Content> =
   | {
       type: 'loading'
       error?: never
@@ -17,6 +17,6 @@ export type FieldPluginResponse =
   | {
       type: 'loaded'
       error?: never
-      data: FieldPluginData
-      actions: FieldPluginActions
+      data: FieldPluginData<Content>
+      actions: FieldPluginActions<Content>
     }

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
@@ -1,7 +1,7 @@
 import { FieldPluginData } from './FieldPluginData'
 import { FieldPluginActions } from './FieldPluginActions'
 
-export type FieldPluginResponse<Content> =
+export type FieldPluginResponse<Content = unknown> =
   | {
       type: 'loading'
       error?: never

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -6,13 +6,18 @@ import { FieldPluginResponse } from './FieldPluginResponse'
 import { createPluginMessageListener } from './createPluginActions/createPluginMessageListener'
 import { sandboxUrl } from './sandboxUrl'
 
+export type FieldPluginOptions<Content> = {
+  parseContent: (content: unknown) => Content
+}
+
 /**
  * @returns cleanup function for side effects
  */
 export const createFieldPlugin = <Content>(
   onUpdateState: (state: FieldPluginResponse<Content>) => void,
-  parseContent: (content: unknown) => Content,
+  options: FieldPluginOptions<Content>,
 ): (() => void) => {
+  const { parseContent } = options
   const isEmbedded = window.parent !== window
 
   if (!isEmbedded) {

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -10,7 +10,7 @@ import { sandboxUrl } from './sandboxUrl'
  * @returns cleanup function for side effects
  */
 export const createFieldPlugin = <Content>(
-  onUpdateState: (state: FieldPluginResponse) => void,
+  onUpdateState: (state: FieldPluginResponse<Content>) => void,
   parseContent: (content: unknown) => Content,
 ): (() => void) => {
   const isEmbedded = window.parent !== window

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -99,7 +99,7 @@ export const createPluginActions = <Content>(
   return {
     actions: {
       setContent: (action) => {
-        const content: Content = isFunction(action)
+        const content: Content = isUpdaterFunction(action)
           ? action(state.content)
           : action
         postToContainer(valueChangeMessage(uid, content))
@@ -110,7 +110,7 @@ export const createPluginActions = <Content>(
         onUpdateState(state)
       },
       setModalOpen: (action) => {
-        const isModalOpen = isFunction(action)
+        const isModalOpen = isUpdaterFunction(action)
           ? action(state.isModalOpen)
           : action
         postToContainer(modalChangeMessage(uid, isModalOpen))
@@ -137,6 +137,6 @@ export const createPluginActions = <Content>(
  * But typescript's does not manage to infer the type after such a check, thus we extract that logic into this utility function.
  * @param setStateAction
  */
-const isFunction = <T>(
+const isUpdaterFunction = <T>(
   setStateAction: SetStateAction<T>,
 ): setStateAction is (state: T) => T => typeof setStateAction === 'function'

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
@@ -6,9 +6,10 @@ import {
 } from '../../messaging'
 
 //TODO: create a test
-export const partialPluginStateFromStateChangeMessage = (
+export const partialPluginStateFromStateChangeMessage = <Content>(
   message: StateChangedMessage,
-): Omit<FieldPluginData, 'isModalOpen'> => ({
+  parseContent: (content: unknown) => Content,
+): Omit<FieldPluginData<Content>, 'isModalOpen'> => ({
   spaceId: message.spaceId ?? undefined,
   story: message.story ?? undefined,
   storyId: message.storyId ?? undefined,
@@ -17,7 +18,7 @@ export const partialPluginStateFromStateChangeMessage = (
   token: message.token ?? undefined,
   options: recordFromFieldPluginOptions(message.schema.options),
   uid: message.uid ?? undefined,
-  content: message.model ?? undefined,
+  content: parseContent(message.model),
 })
 
 export const partialPluginStateFromContextRequestMessage = (

--- a/packages/helper-react/.eslintrc.cjs
+++ b/packages/helper-react/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   env: { browser: true, es2020: true },
   extends: [
     'eslint:recommended',

--- a/packages/helper-react/src/provider.tsx
+++ b/packages/helper-react/src/provider.tsx
@@ -1,37 +1,75 @@
-import { FunctionComponent, useEffect, useState, ComponentType } from 'react'
+import {
+  useEffect,
+  useState,
+  ComponentType,
+  useContext,
+  createContext,
+  FunctionComponent,
+} from 'react'
 import {
   type FieldPluginResponse,
   createFieldPlugin,
 } from '@storyblok/field-plugin'
-import { FieldPluginContext } from './context'
 import { ReactNode } from 'react'
 
-type Props = {
+export type FieldPluginProviderProps = {
   Error?: ComponentType<{ error: Error }>
   Loading?: ComponentType
   children?: ReactNode
 }
 
-export const FieldPluginProvider: FunctionComponent<Props> = ({
-  Error,
-  Loading,
-  children,
-}) => {
-  const [state, setState] = useState<FieldPluginResponse>({
-    type: 'loading',
-  })
+export const createFieldPluginContext = <Content,>(
+  parseContent: (content: unknown) => Content,
+): {
+  FieldPluginProvider: FunctionComponent
+  useFieldPlugin: () => Extract<
+    FieldPluginResponse<Content>,
+    { type: 'loaded' }
+  >
+} => {
+  const FieldPluginContext = createContext<
+    Extract<FieldPluginResponse<Content>, { type: 'loaded' }> | undefined
+  >(undefined)
 
-  useEffect(() => createFieldPlugin(setState), [])
+  const FieldPluginProvider = (
+    props: FieldPluginProviderProps,
+  ): JSX.Element => {
+    const { Error, Loading, children } = props
+    const [state, setState] = useState<FieldPluginResponse<Content>>({
+      type: 'loading',
+    })
 
-  if (state.type === 'loading') {
-    return Loading ? <Loading /> : <></>
-  } else if (state.type === 'error') {
-    return Error ? <Error error={state.error} /> : <></>
-  } else {
-    return (
-      <FieldPluginContext.Provider value={state}>
-        {children}
-      </FieldPluginContext.Provider>
-    )
+    useEffect(() => createFieldPlugin<Content>(setState, parseContent), [])
+
+    if (state.type === 'loading') {
+      return Loading ? <Loading /> : <></>
+    } else if (state.type === 'error') {
+      return Error ? <Error error={state.error} /> : <></>
+    } else {
+      return (
+        <FieldPluginContext.Provider value={state}>
+          {children}
+        </FieldPluginContext.Provider>
+      )
+    }
+  }
+
+  const useFieldPlugin = (): Extract<
+    FieldPluginResponse<Content>,
+    { type: 'loaded' }
+  > => {
+    const plugin = useContext(FieldPluginContext)
+    if (!plugin) {
+      throw new Error(
+        'The plugin is not loaded, yet `useFieldPlugin()` was invoked. Ensure that the component that invoked `useFieldPlugin()` is wrapped within `<FieldPluginProvider>`.',
+      )
+    }
+
+    return plugin as Extract<FieldPluginResponse<Content>, { type: 'loaded' }>
+  }
+
+  return {
+    FieldPluginProvider,
+    useFieldPlugin,
   }
 }

--- a/packages/helper-react/src/useFieldPlugin.ts
+++ b/packages/helper-react/src/useFieldPlugin.ts
@@ -2,8 +2,8 @@ import { FieldPluginResponse } from '@storyblok/field-plugin'
 import { useContext } from 'react'
 import { FieldPluginContext } from './context'
 
-export const useFieldPlugin = (): Extract<
-  FieldPluginResponse,
+export const useFieldPlugin = <Content>(): Extract<
+  FieldPluginResponse<Content>,
   { type: 'loaded' }
 > => {
   const plugin = useContext(FieldPluginContext)
@@ -13,5 +13,5 @@ export const useFieldPlugin = (): Extract<
     )
   }
 
-  return plugin
+  return plugin as Extract<FieldPluginResponse<Content>, { type: 'loaded' }>
 }

--- a/packages/helper-vue3/src/FieldPluginProvider.vue
+++ b/packages/helper-vue3/src/FieldPluginProvider.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
-import { provide, reactive } from 'vue'
+import { onMounted, provide, reactive } from 'vue'
 import {
   createFieldPlugin,
   FieldPluginResponse,
   FieldPluginData,
 } from '@storyblok/field-plugin'
 import { convertToRaw } from '../utils'
+
+const props = defineProps<{
+  parseContent: (unknown: unknown) => unknown
+}>()
 
 const plugin = reactive<FieldPluginResponse>({
   type: 'loading',
@@ -26,7 +30,7 @@ const updateObjectWithoutChangingReference = (
   Object.assign(originalObject, newObject)
 }
 
-createFieldPlugin((newState) => {
+const onUpdateState = (newState: FieldPluginResponse) => {
   // Instead of replacing `plugin.data` which loses the reactive reference,
   // we're assigning each property into `plugin.data`.
 
@@ -65,7 +69,8 @@ createFieldPlugin((newState) => {
 
   plugin.type = newState.type
   plugin.error = newState.error
-})
+}
+onMounted(() => createFieldPlugin(onUpdateState, props.parseContent))
 provide('field-plugin', plugin)
 </script>
 

--- a/packages/helper-vue3/src/useFieldPlugin.ts
+++ b/packages/helper-vue3/src/useFieldPlugin.ts
@@ -1,8 +1,11 @@
 import { inject } from 'vue'
-import { type FieldPluginResponse } from '@storyblok/field-plugin'
+import { FieldPluginResponse } from '@storyblok/field-plugin'
 
-export const useFieldPlugin = () => {
-  const plugin = inject<FieldPluginResponse>(
+export const useFieldPlugin = <Content>(): Extract<
+  FieldPluginResponse<Content>,
+  { type: 'loaded' }
+> => {
+  const plugin = inject<FieldPluginResponse<Content>>(
     'field-plugin',
     () => {
       throw new Error(


### PR DESCRIPTION
Issue: EXT-1611, #201

## What?

Strongly typed `content` and `setContent`.

## Why?

Until now, we have left validation/parsing completely up to the user. But the content should always be validated, so it's best to encourage the users to do it by including it in the library. It especially became an issue when we introduced the content updater functions, because the `content` argument in the updater function does not have to adhere to the schema that the user expects, but can be an unknown value; for example `""` or `undefined` when the field plugin is initiated.

```ts
// We cannot assume anything about the structure of `content` here
setContent(
  (content: unknown) => ...
)
```  

## How to test? (optional)

TODO