### PR TITLE
chore(common): update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "weekly"
-      time: "19:00"
-      timezone: "Europe/Vienna"
-      day: "thursday"
+      interval: 'weekly'
+      time: '19:00'
+      timezone: 'Europe/Vienna'
+      day: 'thursday'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
     groups:
       all:
         patterns:
-          - "*"
+          - '*'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [ opened, edited, synchronize, reopened ]
+    types: [opened, edited, synchronize, reopened]
 
 # https://github.com/amannn/action-semantic-pull-request
 jobs:
@@ -19,4 +19,5 @@ jobs:
             template
             demo
             helper
+            deps
           requireScope: true


### PR DESCRIPTION
## What?

`dependabot` created #250, which includes major version updates. So this PR

- re-configure dependabot only to upgrade minor and patch versions
- and include `deps` as a PR title scope like `chore(deps)`
