### PR TITLE
docs(template): add readme instruction to remove loading state

### DIFF
--- a/packages/cli/templates/react/README.md
+++ b/packages/cli/templates/react/README.md
@@ -43,3 +43,5 @@ npm run deploy --name $NAME --skipPrompts
 ## Clean up the boilerplate
 
 To start from a blank state, remove the example component `<FieldPluginExample />` from `src/App.tsx` with `<FieldPlugin />`.
+
+To avoid a flickering “Loading…” message during rendering, from `src/App.tsx`, also remove the `Loading` parameter when calling `FieldPluginProvider` component.

--- a/packages/cli/templates/vue2/README.md
+++ b/packages/cli/templates/vue2/README.md
@@ -37,3 +37,5 @@ npm run deploy --name $NAME --skipPrompts
 ## Clean up the boilerplate
 
 To start from a blank state, remove the example component `<FieldPluginExample />` from `src/App.vue` with `<FieldPlugin />`.
+
+To avoid a flickering “Loading…” message during rendering, from `src/App.vue`, also remove `v-slot:loading` template inside `FieldPluginProvider`.

--- a/packages/cli/templates/vue3/README.md
+++ b/packages/cli/templates/vue3/README.md
@@ -45,3 +45,5 @@ npm run deploy --name $NAME --skipPrompts
 ## Clean up the boilerplate
 
 To start from a blank state, replace the example component `<FieldPluginExample />` from `src/App.vue` with `<FieldPlugin />`.
+
+To avoid a flickering “Loading…” message during rendering, from `src/App.vue`, also remove `v-slot:loading` template inside `FieldPluginProvider`.


### PR DESCRIPTION
## What?
Add readme instructions to remove the loading state

## Why?

JIRA: EXT-1726

It's a default behavior, after creating a fresh new field-plugin, to have a `loading` state inside the autogenerated FieldPluginProvider (created by the CLI).

This state shows a 'loading...' message during the field-plugin render process, however, it happens so quickly that it flicks and the user can't even see it appearing.

To avoid this flickering “Loading…” message to happen, instructions for removing it were added for React, Vue2, and Vue3 templates.

![Screenshot 2023-08-17 at 08 29 06](https://github.com/storyblok/field-plugin/assets/1240591/dfbaade6-f051-4c6b-a45b-59e57cdb0f01)

