### PR TITLE
feat(lib): handle `callbackId` in `contextRequest`

### DIFF
--- a/packages/container/src/components/FieldPluginContainer.tsx
+++ b/packages/container/src/components/FieldPluginContainer.tsx
@@ -77,8 +77,9 @@ const useSandbox = (
       return undefined
     }
     // Omitting query parameters from the user-provided URL in a safe way
-    return `${fieldPluginURL.origin}${fieldPluginURL.pathname
-      }?${urlSearchParamsFromPluginUrlParams(pluginParams)}`
+    return `${fieldPluginURL.origin}${
+      fieldPluginURL.pathname
+    }?${urlSearchParamsFromPluginUrlParams(pluginParams)}`
   }, [fieldPluginURL, pluginParams])
   const [iframeKey, setIframeKey] = useState(0)
 
@@ -157,11 +158,12 @@ const useSandbox = (
   )
 
   const onContextRequested = useCallback(
-    () =>
+    (callbackId: string) =>
       dispatchContextRequest({
         uid,
         action: 'get-context',
         story: loadedData.story,
+        callbackId,
       }),
     [uid, dispatchContextRequest, loadedData.story],
   )

--- a/packages/container/src/dom/createContainerMessageListener.ts
+++ b/packages/container/src/dom/createContainerMessageListener.ts
@@ -7,7 +7,6 @@ import {
   isPluginLoadedMessage,
   isValueChangeMessage,
   PluginLoadedMessage,
-  RequestContext,
   SetContent,
   SetModalOpen,
 } from '@storyblok/field-plugin'
@@ -17,7 +16,7 @@ type ContainerActions = {
   setContent: SetContent
   setModalOpen: SetModalOpen
   setPluginReady: (message: PluginLoadedMessage) => void
-  requestContext: RequestContext
+  requestContext: (callbackId: string) => void
   selectAsset: (callbackId: string, field: string) => void
 }
 

--- a/packages/container/src/dom/createContainerMessageListener.ts
+++ b/packages/container/src/dom/createContainerMessageListener.ts
@@ -55,7 +55,10 @@ export const createContainerMessageListener: CreateContainerListener = (
     } else if (isHeightChangeMessage(message)) {
       eventHandlers.setHeight(message.height)
     } else if (isAssetModalChangeMessage(message)) {
-      eventHandlers.selectAsset(message.callbackId, message.field ?? '')
+      eventHandlers.selectAsset(
+        message.callbackId as string,
+        message.field ?? '',
+      )
     } else if (isGetContextMessage(message)) {
       eventHandlers.requestContext()
     } else {

--- a/packages/container/src/dom/createContainerMessageListener.ts
+++ b/packages/container/src/dom/createContainerMessageListener.ts
@@ -55,12 +55,9 @@ export const createContainerMessageListener: CreateContainerListener = (
     } else if (isHeightChangeMessage(message)) {
       eventHandlers.setHeight(message.height)
     } else if (isAssetModalChangeMessage(message)) {
-      eventHandlers.selectAsset(
-        message.callbackId as string,
-        message.field ?? '',
-      )
+      eventHandlers.selectAsset(message.callbackId, message.field ?? '')
     } else if (isGetContextMessage(message)) {
-      eventHandlers.requestContext(message.callbackId as string)
+      eventHandlers.requestContext(message.callbackId)
     } else {
       console.warn(
         `Container received unknown message from plugin: ${JSON.stringify(

--- a/packages/container/src/dom/createContainerMessageListener.ts
+++ b/packages/container/src/dom/createContainerMessageListener.ts
@@ -60,7 +60,7 @@ export const createContainerMessageListener: CreateContainerListener = (
         message.field ?? '',
       )
     } else if (isGetContextMessage(message)) {
-      eventHandlers.requestContext()
+      eventHandlers.requestContext(message.callbackId as string)
     } else {
       console.warn(
         `Container received unknown message from plugin: ${JSON.stringify(

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
@@ -1,9 +1,9 @@
-import { Asset } from '../messaging'
+import { Asset, ContextRequestMessage } from '../messaging'
 
 export type SetStateAction<T> = T | ((value: T) => T)
 export type SetContent = <C>(setContentAction: SetStateAction<C>) => void
 export type SetModalOpen = (setModalOpenAction: SetStateAction<boolean>) => void
-export type RequestContext = () => void
+export type RequestContext = () => Promise<ContextRequestMessage>
 export type SelectAsset = () => Promise<Asset>
 
 export type FieldPluginActions = {

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -85,7 +85,7 @@ export const createPluginActions: CreatePluginActions = (
 
     // We do not reject the promise here.
     // There can be another instance of `createFieldPlugin()`,
-    // calling `selectAsset` with different `callbackId`.
+    // calling `requestContext` with different `callbackId`.
     // In such case, we should simply ignore the callback.
     // We may get another callback with correct `callbackId`.
     if (data.callbackId === requestContextCallbackId) {

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/handlePluginMessage.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/handlePluginMessage.test.ts
@@ -8,6 +8,8 @@ import {
 } from '../../../messaging'
 
 const uid = 'abc123'
+const callbackId = 'test-callback-id'
+
 const mockCallbacks = (): PluginMessageCallbacks => ({
   onStateChange: jest.fn(),
   onContextRequest: jest.fn(),
@@ -73,6 +75,7 @@ describe('handlePluginMessage', () => {
     const data: ContextRequestMessage = {
       action: 'get-context',
       uid,
+      callbackId,
       story: { content: {} },
     }
     const callbacks = mockCallbacks()
@@ -88,7 +91,7 @@ describe('handlePluginMessage', () => {
       uid,
       filename: '/my-file.jpg',
       field: 'callback-uid',
-      callbackId: 'test-callback-id',
+      callbackId,
     }
     const callbacks = mockCallbacks()
     handlePluginMessage(data, uid, callbacks)

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/ContextRequestMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/ContextRequestMessage.test.ts
@@ -1,0 +1,106 @@
+import {
+  ContextRequestMessage,
+  isContextRequestMessage,
+} from './ContextRequestMessage'
+
+const stub: ContextRequestMessage = {
+  uid: 'abc',
+  story: { content: {} },
+  action: 'get-context',
+  callbackId: 'test-callback-id',
+}
+
+describe('ContextRequestMessage', () => {
+  it('should validate', () => {
+    expect(isContextRequestMessage(stub)).toEqual(true)
+  })
+
+  describe('The "action" property', () => {
+    it('equals "get-context"', () => {
+      expect(
+        isContextRequestMessage({
+          ...stub,
+          action: 'anotherString',
+        }),
+      ).toEqual(false)
+    })
+  })
+
+  describe('the "uid" property', () => {
+    it('is a string', () => {
+      expect(
+        isContextRequestMessage({
+          ...stub,
+          uid: 'anything',
+        }),
+      ).toEqual(true)
+    })
+
+    it('is not undefined', () => {
+      expect(
+        isContextRequestMessage({
+          ...stub,
+          uid: undefined,
+        }),
+      ).toEqual(false)
+    })
+
+    it('is not null', () => {
+      expect(
+        isContextRequestMessage({
+          ...stub,
+          uid: null,
+        }),
+      ).toEqual(false)
+    })
+
+    it('is not a number', () => {
+      expect(
+        isContextRequestMessage({
+          ...stub,
+          uid: 123,
+        }),
+      ).toEqual(false)
+    })
+  })
+
+  describe('the "story" property', () => {
+    it('is not undefined', () => {
+      expect(
+        isContextRequestMessage({
+          ...stub,
+          story: undefined,
+        }),
+      ).toEqual(false)
+    })
+
+    it('is not null', () => {
+      expect(
+        isContextRequestMessage({
+          ...stub,
+          story: null,
+        }),
+      ).toEqual(false)
+    })
+  })
+
+  describe('the "callbackId" property', () => {
+    it('is not undefined', () => {
+      expect(
+        isContextRequestMessage({
+          ...stub,
+          callbackId: undefined,
+        }),
+      ).toEqual(false)
+    })
+
+    it('is not null', () => {
+      expect(
+        isContextRequestMessage({
+          ...stub,
+          callbackId: null,
+        }),
+      ).toEqual(false)
+    })
+  })
+})

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/ContextRequestMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/ContextRequestMessage.ts
@@ -5,6 +5,13 @@ import { isStoryData, StoryData } from './StoryData'
 //TODO: tests
 export type ContextRequestMessage = MessageToPlugin<'get-context'> & {
   story: StoryData
+  callbackId: string
+}
+
+const hasCallbackId = (
+  obj: unknown,
+): obj is Pick<ContextRequestMessage, 'callbackId'> => {
+  return hasKey(obj, 'callbackId') && typeof obj.callbackId === 'string'
 }
 
 export const isContextRequestMessage = (
@@ -13,4 +20,5 @@ export const isContextRequestMessage = (
   isMessageToPlugin(data) &&
   data.action === 'get-context' &&
   hasKey(data, 'story') &&
+  hasCallbackId(data) &&
   isStoryData(data.story)

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/GetContextMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/GetContextMessage.test.ts
@@ -6,10 +6,13 @@ import {
 } from './GetContextMessage'
 
 const uid = '-preview-abc-123'
+const callbackId = 'test-callback-id'
+
 const stub: GetContextMessage = {
   action: 'plugin-changed',
   event: 'getContext',
   uid,
+  callbackId,
 }
 
 describe('ValueChangeMessage', () => {
@@ -34,7 +37,14 @@ describe('ValueChangeMessage', () => {
   })
   describe('constructor', () => {
     it('includes the uid', () => {
-      expect(getContextMessage(uid)).toHaveProperty('uid', uid)
+      expect(getContextMessage(uid, callbackId)).toHaveProperty('uid', uid)
+    })
+
+    it('includes the callbackId', () => {
+      expect(getContextMessage(uid, callbackId)).toHaveProperty(
+        'callbackId',
+        callbackId,
+      )
     })
   })
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/GetContextMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/GetContextMessage.ts
@@ -1,12 +1,25 @@
+import { hasKey } from '../../../../src/utils'
 import { isMessageToContainer, MessageToContainer } from './MessageToContainer'
 
-export type GetContextMessage = MessageToContainer<'getContext'>
+export type GetContextMessage = MessageToContainer<'getContext'> & {
+  callbackId: string
+}
 
 export const isGetContextMessage = (obj: unknown): obj is GetContextMessage =>
-  isMessageToContainer(obj) && obj.event === 'getContext'
+  isMessageToContainer(obj) && obj.event === 'getContext' && hasCallbackId(obj)
 
-export const getContextMessage = (uid: string): GetContextMessage => ({
+const hasCallbackId = (
+  obj: unknown,
+): obj is Pick<GetContextMessage, 'callbackId'> => {
+  return hasKey(obj, 'callbackId') && typeof obj.callbackId === 'string'
+}
+
+export const getContextMessage = (
+  uid: string,
+  callbackId: string,
+): GetContextMessage => ({
   action: 'plugin-changed',
   event: 'getContext',
   uid,
+  callbackId,
 })


### PR DESCRIPTION
## What?
Modify the requestContext action to return a Promise in place of returning nothing.

## Why?

JIRA: EXT-1920

The corresponding pull request in Storyfront is a prerequisite: https://github.com/storyblok/storyfront/pull/4368

This PR has the same purpose (and approach) as [this one](https://github.com/storyblok/field-plugin/pull/253) but is now for the `getContext` action (not `selectAsset`)

Usage implementation:
![image](https://github.com/storyblok/field-plugin/assets/1240591/0c021bc7-f720-4b59-931f-19fb0b3fa630)

Result:
![image](https://github.com/storyblok/field-plugin/assets/1240591/cfbbb2ca-7a3f-49cd-a501-0bea749164f7)

## How to test? (optional)
This function can be tested using our Sandbox application as described in or [[CONTRIBUTING.md →](https://github.com/storyblok/field-plugin/blob/main/CONTRIBUTING.md)]