### PR TITLE
feat(lib): add parseContent

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginActions.ts
@@ -1,15 +1,19 @@
 import { Asset, StoryData } from '../messaging'
 import { FieldPluginData } from './FieldPluginData'
 
-export type SetContent = <C>(content: C) => Promise<FieldPluginData>
-export type SetModalOpen = (isModalOpen: boolean) => Promise<FieldPluginData>
+export type SetContent<Content> = (
+  content: Content,
+) => Promise<FieldPluginData<Content>>
+export type SetModalOpen<Content> = (
+  isModalOpen: boolean,
+) => Promise<FieldPluginData<Content>>
 export type RequestContext = () => Promise<StoryData>
 export type SelectAsset = () => Promise<Asset>
-export type Initialize = () => Promise<FieldPluginData>
+export type Initialize<Content> = () => Promise<FieldPluginData<Content>>
 
-export type FieldPluginActions = {
-  setContent: SetContent
-  setModalOpen: SetModalOpen
+export type FieldPluginActions<Content> = {
+  setContent: SetContent<Content>
+  setModalOpen: SetModalOpen<Content>
   requestContext: RequestContext
   selectAsset: SelectAsset
 }

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
@@ -3,9 +3,9 @@
  */
 import { StoryData } from '../messaging'
 
-export type FieldPluginData = {
+export type FieldPluginData<Content> = {
   isModalOpen: boolean
-  content: unknown
+  content: Content
   options: Record<string, string>
   spaceId: number | undefined
   storyLang: string

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
@@ -1,22 +1,22 @@
 import { FieldPluginData } from './FieldPluginData'
 import { FieldPluginActions } from './FieldPluginActions'
 
-export type FieldPluginResponse =
-  | {
-      type: 'loading'
-      error?: never
-      data?: never
-      actions?: never
+export type FieldPluginResponse<Content> =
+    | {
+        type: 'loading'
+        error?: never
+        data?: never
+        actions?: never
     }
-  | {
-      type: 'error'
-      error: Error
-      data?: never
-      actions?: never
+    | {
+        type: 'error'
+        error: Error
+        data?: never
+        actions?: never
     }
-  | {
-      type: 'loaded'
-      error?: never
-      data: FieldPluginData
-      actions: FieldPluginActions
+    | {
+        type: 'loaded'
+        error?: never
+        data: FieldPluginData<Content>
+        actions: FieldPluginActions<Content>
     }

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginResponse.ts
@@ -2,21 +2,21 @@ import { FieldPluginData } from './FieldPluginData'
 import { FieldPluginActions } from './FieldPluginActions'
 
 export type FieldPluginResponse<Content> =
-    | {
-        type: 'loading'
-        error?: never
-        data?: never
-        actions?: never
+  | {
+      type: 'loading'
+      error?: never
+      data?: never
+      actions?: never
     }
-    | {
-        type: 'error'
-        error: Error
-        data?: never
-        actions?: never
+  | {
+      type: 'error'
+      error: Error
+      data?: never
+      actions?: never
     }
-    | {
-        type: 'loaded'
-        error?: never
-        data: FieldPluginData<Content>
-        actions: FieldPluginActions<Content>
+  | {
+      type: 'loaded'
+      error?: never
+      data: FieldPluginData<Content>
+      actions: FieldPluginActions<Content>
     }

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -1,20 +1,24 @@
 import { createPluginActions } from './createPluginActions'
 import { createHeightChangeListener } from './createHeightChangeListener'
 import { disableDefaultStoryblokStyles } from './disableDefaultStoryblokStyles'
-import { pluginLoadedMessage, pluginUrlParamsFromUrl } from '../messaging'
+import { pluginUrlParamsFromUrl } from '../messaging'
 import { FieldPluginResponse } from './FieldPluginResponse'
 import { createPluginMessageListener } from './createPluginActions/createPluginMessageListener'
 import { sandboxUrl } from './sandboxUrl'
 import { isCloneable } from '../utils/isCloneable'
 
-export type CreateFieldPlugin = (
-  onUpdate: (state: FieldPluginResponse) => void,
-) => () => void
+export type CreateFieldPlugin = <Content = unknown>(options: {
+  onUpdateState: (state: FieldPluginResponse<Content>) => void
+  parseContent: (content: unknown) => Content
+}) => () => void
 
 /**
  * @returns cleanup function for side effects
  */
-export const createFieldPlugin: CreateFieldPlugin = (onUpdateState) => {
+export const createFieldPlugin: CreateFieldPlugin = ({
+  onUpdateState,
+  parseContent,
+}) => {
   const isEmbedded = window.parent !== window
 
   if (!isEmbedded) {
@@ -55,10 +59,10 @@ export const createFieldPlugin: CreateFieldPlugin = (onUpdateState) => {
       // eslint-disable-next-line functional/no-throw-statement
       throw new Error(
         'The argument could not be cloned. ' +
-          'The argument must be cloneable with structuredClone(), so that it can be sent to other windows with window.postMessage(). ' +
-          'Does your object contain functions, getters, setters, proxies, or any other value that is not cloneable? Did you try to pass a reactive object? ' +
-          'For a full description on the structuredClone algorithm, see: ' +
-          'https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm',
+        'The argument must be cloneable with structuredClone(), so that it can be sent to other windows with window.postMessage(). ' +
+        'Does your object contain functions, getters, setters, proxies, or any other value that is not cloneable? Did you try to pass a reactive object? ' +
+        'For a full description on the structuredClone algorithm, see: ' +
+        'https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm',
         {
           cause: err,
         },
@@ -69,12 +73,17 @@ export const createFieldPlugin: CreateFieldPlugin = (onUpdateState) => {
   const cleanupStyleSideEffects = disableDefaultStoryblokStyles()
 
   const { actions, messageCallbacks, onHeightChange, initialize } =
-    createPluginActions(uid, postToContainer, (data) => {
-      onUpdateState({
-        type: 'loaded',
-        data,
-        actions,
-      })
+    createPluginActions({
+      uid,
+      postToContainer,
+      onUpdateState: (data) => {
+        onUpdateState({
+          type: 'loaded',
+          data,
+          actions,
+        })
+      },
+      parseContent,
     })
 
   const cleanupHeightChangeListener = createHeightChangeListener(onHeightChange)

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -59,10 +59,10 @@ export const createFieldPlugin: CreateFieldPlugin = ({
       // eslint-disable-next-line functional/no-throw-statement
       throw new Error(
         'The argument could not be cloned. ' +
-        'The argument must be cloneable with structuredClone(), so that it can be sent to other windows with window.postMessage(). ' +
-        'Does your object contain functions, getters, setters, proxies, or any other value that is not cloneable? Did you try to pass a reactive object? ' +
-        'For a full description on the structuredClone algorithm, see: ' +
-        'https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm',
+          'The argument must be cloneable with structuredClone(), so that it can be sent to other windows with window.postMessage(). ' +
+          'Does your object contain functions, getters, setters, proxies, or any other value that is not cloneable? Did you try to pass a reactive object? ' +
+          'For a full description on the structuredClone algorithm, see: ' +
+          'https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm',
         {
           cause: err,
         },

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
@@ -31,18 +31,30 @@ const wait = async (ms: number) => {
   })
 }
 
+const parseContent = (content: unknown) => content
+
 describe('createPluginActions', () => {
   describe('initial call', () => {
     it('does not send any message to the container', () => {
       const { uid, postToContainer, onUpdateState } = mock()
-      createPluginActions(uid, postToContainer, onUpdateState)
+      createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       expect(postToContainer).not.toHaveBeenCalled()
     })
     it('updates the state when received from container', () => {
       const { uid, postToContainer, onUpdateState } = mock()
       const {
         messageCallbacks: { onLoaded },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
+      } = createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       const randomString = '3490ruieo4jf984ej89q32jd0i2k3w09k3902'
       onLoaded({
         action: 'loaded',
@@ -69,7 +81,12 @@ describe('createPluginActions', () => {
       const { uid, postToContainer, onUpdateState } = mock()
       const {
         actions: { setModalOpen },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
+      } = createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       setModalOpen(false)
 
       expect(postToContainer).toHaveBeenLastCalledWith(
@@ -89,7 +106,12 @@ describe('createPluginActions', () => {
       const { uid, postToContainer, onUpdateState } = mock()
       const {
         actions: { setModalOpen },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
+      } = createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       setModalOpen(false)
 
       expect(postToContainer).toHaveBeenCalledWith(
@@ -113,7 +135,12 @@ describe('createPluginActions', () => {
       const { uid, postToContainer, onUpdateState } = mock()
       const {
         actions: { setContent },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
+      } = createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       const content = '409fjk340wo9jkc0954ij0943iu09c43*&(YT-0c43'
       setContent(content)
       expect(postToContainer).toHaveBeenLastCalledWith(
@@ -126,7 +153,12 @@ describe('createPluginActions', () => {
       const { uid, postToContainer, onUpdateState } = mock()
       const {
         actions: { setContent },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
+      } = createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       const content = '0932ui2foiuerhjv98453jeh09c34jwk-0c43'
       setContent(content)
       expect(postToContainer).toHaveBeenLastCalledWith(
@@ -142,7 +174,12 @@ describe('createPluginActions', () => {
       const { uid, postToContainer, onUpdateState } = mock()
       const {
         actions: { requestContext },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
+      } = createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       requestContext()
       expect(postToContainer).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -156,7 +193,12 @@ describe('createPluginActions', () => {
       const { uid, postToContainer, onUpdateState } = mock()
       const {
         actions: { selectAsset },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
+      } = createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       selectAsset()
       expect(postToContainer).toHaveBeenLastCalledWith(
@@ -170,7 +212,12 @@ describe('createPluginActions', () => {
       const {
         actions: { selectAsset },
         messageCallbacks: { onAssetSelect },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
+      } = createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       const promise = selectAsset()
       const filename = 'hello.jpg'
       onAssetSelect({
@@ -189,7 +236,12 @@ describe('createPluginActions', () => {
       const {
         actions: { selectAsset },
         messageCallbacks: { onAssetSelect },
-      } = createPluginActions(uid, postToContainer, onUpdateState)
+      } = createPluginActions({
+        uid,
+        postToContainer,
+        onUpdateState,
+        parseContent,
+      })
       const promise = selectAsset()
       const filename = 'hello.jpg'
       onAssetSelect({

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -61,7 +61,8 @@ export const createPluginActions: CreatePluginActions = ({
     // TODO remove side-effect, making functions in this file pure.
     //  perhaps only show this message in development mode?
     console.debug(
-      `Plugin received a message from container of an unknown action type "${data.action
+      `Plugin received a message from container of an unknown action type "${
+        data.action
       }". You may need to upgrade the version of the @storyblok/field-plugin library. Full message: ${JSON.stringify(
         data,
       )}`,
@@ -85,7 +86,7 @@ export const createPluginActions: CreatePluginActions = ({
       setContent: (content) => {
         return new Promise((resolve) => {
           const callbackId = pushCallback('stateChanged', (message) =>
-            resolve(pluginStateFromStateChangeMessage(message)),
+            resolve(pluginStateFromStateChangeMessage(message, parseContent)),
           )
           postToContainer(
             valueChangeMessage({ uid, callbackId, model: content }),
@@ -95,7 +96,7 @@ export const createPluginActions: CreatePluginActions = ({
       setModalOpen: (isModalOpen) => {
         return new Promise((resolve) => {
           const callbackId = pushCallback('stateChanged', (message) =>
-            resolve(pluginStateFromStateChangeMessage(message)),
+            resolve(pluginStateFromStateChangeMessage(message, parseContent)),
           )
           postToContainer(
             modalChangeMessage({ uid, callbackId, status: isModalOpen }),
@@ -124,7 +125,7 @@ export const createPluginActions: CreatePluginActions = ({
     initialize: () => {
       return new Promise((resolve) => {
         const callbackId = pushCallback('loaded', (message) =>
-          resolve(pluginStateFromStateChangeMessage(message)),
+          resolve(pluginStateFromStateChangeMessage(message, parseContent)),
         )
         // Request the initial state from the Visual Editor.
         postToContainer(pluginLoadedMessage({ uid, callbackId }))

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -32,7 +32,7 @@ export type CreatePluginActions = <Content>(options: {
   // This function is called whenever the height changes
   onHeightChange: (height: number) => void
   // This initiates the plugin
-  initialize: Initialize
+  initialize: Initialize<Content>
 }
 
 export const createPluginActions: CreatePluginActions = ({

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
@@ -5,9 +5,10 @@ import {
   StateChangedMessage,
 } from '../../messaging'
 
-export const pluginStateFromStateChangeMessage = (
+export const pluginStateFromStateChangeMessage = <Content>(
   message: LoadedMessage | StateChangedMessage,
-): FieldPluginData => ({
+  parseContent: (content: unknown) => Content,
+): FieldPluginData<Content> => ({
   spaceId: message.spaceId ?? undefined,
   story: message.story ?? undefined,
   storyId: message.storyId ?? undefined,
@@ -16,6 +17,6 @@ export const pluginStateFromStateChangeMessage = (
   token: message.token ?? undefined,
   options: recordFromFieldPluginOptions(message.schema.options),
   uid: message.uid ?? undefined,
-  content: message.model ?? undefined,
+  content: parseContent(message.model),
   isModalOpen: message.isModalOpen,
 })


### PR DESCRIPTION
## What?

This PR adds `parseContent` as the option to `createFieldPlugin()` function. This makes sure that we always pass around correctly formed payload.

This is almost the exact porting of #241. @johannes-lindgren did the job there, but since #260, it was too hard to resolve conflicts. So I've created a new PR here.

## Why?

JIRA: EXT-1918

more discussion on #241 

## Notice

It's expected to see tests broken in this pull request, as the demo and the helpers are not taking this change into account. It will be fixed in the separate pull request.