### PR TITLE
fix(template): adapting to the new way resizing of the field plugin is handled

### DIFF
--- a/packages/cli/templates/js/src/style.css
+++ b/packages/cli/templates/js/src/style.css
@@ -1,176 +1,179 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
 html {
-  overflow: hidden;
+    overflow: hidden;
+    height: 100%;
 }
 
 :root {
-  /*Storyblok colors*/
-  --sb_green: #00b3b0;
-  --sb_green_75: #40c6c4;
-  --sb_green_50: #7fd9d7;
-  --sb_green_25: #d9f4f3;
-  --sb_dark_blue: #1b243f;
-  --sb_dark_blue_75: #545b6f;
-  --sb_dark_blue_50: #8d919f;
-  --sb_dark_blue_25: #c6c8cf;
-  --green: #2db47d;
-  --green_75: #62c79e;
-  --green_50: #96d9be;
-  --green_25: #caecde;
-  --green_disabled: #004e4c;
-  --yellow: #fbce41;
-  --yellow_75: #fcdb71;
-  --yellow_50: #fde6a0;
-  --yellow_25: #fef3cf;
-  --blue: #395ece;
-  --blue_75: #6b87db;
-  --blue_50: #9caee6;
-  --blue_25: #cdd7f3;
-  --orange: #ffac00;
-  --orange_75: #ffc140;
-  --orange_50: #ffd57f;
-  --orange_25: #ffeabf;
-  --red: #ff6159;
-  --red_75: #ff8983;
-  --red_50: #ffb0ac;
-  --red_25: #ffd7d5;
-  --light: #dfe3e8;
-  --light_75: #e7eaee;
-  --light_50: #eff1f3;
-  --light_25: #f7f8f9;
-  --light_gray: #b1b5be;
-  --black: #101525;
-  --white: #fff;
+    /*Storyblok colors*/
+    --sb_green: #00b3b0;
+    --sb_green_75: #40c6c4;
+    --sb_green_50: #7fd9d7;
+    --sb_green_25: #d9f4f3;
+    --sb_dark_blue: #1b243f;
+    --sb_dark_blue_75: #545b6f;
+    --sb_dark_blue_50: #8d919f;
+    --sb_dark_blue_25: #c6c8cf;
+    --green: #2db47d;
+    --green_75: #62c79e;
+    --green_50: #96d9be;
+    --green_25: #caecde;
+    --green_disabled: #004e4c;
+    --yellow: #fbce41;
+    --yellow_75: #fcdb71;
+    --yellow_50: #fde6a0;
+    --yellow_25: #fef3cf;
+    --blue: #395ece;
+    --blue_75: #6b87db;
+    --blue_50: #9caee6;
+    --blue_25: #cdd7f3;
+    --orange: #ffac00;
+    --orange_75: #ffc140;
+    --orange_50: #ffd57f;
+    --orange_25: #ffeabf;
+    --red: #ff6159;
+    --red_75: #ff8983;
+    --red_50: #ffb0ac;
+    --red_25: #ffd7d5;
+    --light: #dfe3e8;
+    --light_75: #e7eaee;
+    --light_50: #eff1f3;
+    --light_25: #f7f8f9;
+    --light_gray: #b1b5be;
+    --black: #101525;
+    --white: #fff;
 
-  font-family: 'Roboto', sans-serif;
-  font-style: normal;
-  line-height: 1.5;
-  font-weight: 400;
-  font-size: 1rem;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
+    font-family: 'Roboto', sans-serif;
+    font-style: normal;
+    line-height: 1.5;
+    font-weight: 400;
+    font-size: 1rem;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-text-size-adjust: 100%;
 }
 
 #app {
-  width: 100%;
+    width: 100%;
 }
 
 /*Element Styles*/
 body {
-  margin: 0;
-  display: flex;
-  box-sizing: border-box;
+    margin: 0;
+    display: flex;
+    box-sizing: border-box;
 }
 
 /* #region DELETE THIS BOILERPLATE */
 /*Layout Styles*/
 .container {
-  max-width: 22rem;
-  margin: 0 auto;
-  background-color: #ffffff;
-  border: 1px solid var(--light);
-  padding: 15px;
-  border-radius: 5px;
+    max-width: 22rem;
+    margin: 0 auto;
+    background-color: #ffffff;
+    border: 1px solid var(--light);
+    padding: 15px;
+    border-radius: 5px;
 }
 
 h2 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  font-weight: 500;
-  margin: 1rem 0;
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+    font-weight: 500;
+    margin: 1rem 0;
 }
 
 hr {
-  border-top: 1px dashed var(--light);
-  border-bottom: 0;
-  border-left: 0;
-  border-right: 0;
-  margin: 1.25rem 0;
+    border-top: 1px dashed var(--light);
+    border-bottom: 0;
+    border-left: 0;
+    border-right: 0;
+    margin: 1.25rem 0;
 }
 
 .counter-value {
-  margin-top: 1.25rem;
-  margin-bottom: 1rem;
-  font-size: 1.625rem;
-  font-weight: 700;
-  text-align: center;
+    margin-top: 1.25rem;
+    margin-bottom: 1rem;
+    font-size: 1.625rem;
+    font-weight: 700;
+    text-align: center;
 }
 
 .btn {
-  font-size: 0.875rem;
-  font-weight: 500;
-  padding: 0.8125rem 1rem;
-  background: transparent;
-  border: 1px solid var(--light);
-  border-radius: 0.3125rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease-in-out;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.8125rem 1rem;
+    background: transparent;
+    border: 1px solid var(--light);
+    border-radius: 0.3125rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out;
 }
 
 .w-full {
-  width: 100%;
+    width: 100%;
 }
 
 .btn:hover {
-  background-color: var(--light_75);
+    background-color: var(--light_75);
 }
 
 .btn-close {
-  position: absolute;
-  top: 0;
-  right: 0;
-  border: 0;
+    position: fixed;
+    top: 0;
+    right: 0;
+    border: 0;
 }
 
 .btn-close:hover {
-  background-color: var(--light_75);
+    background-color: var(--light_75);
 }
 
 .asset-selector img {
-  width: 100%;
-  display: block;
-  margin-bottom: 1rem;
+    width: 100%;
+    display: block;
+    margin-bottom: 1rem;
 }
 
 .sr-only {
-  position: absolute !important;
-  clip: rect(1px, 1px, 1px, 1px);
-  padding: 0 !important;
-  border: 0 !important;
-  height: 1px !important;
-  width: 1px !important;
-  overflow: hidden;
+    position: absolute !important;
+    clip: rect(1px, 1px, 1px, 1px);
+    padding: 0 !important;
+    border: 0 !important;
+    height: 1px !important;
+    width: 1px !important;
+    overflow: hidden;
 }
 
 /* js template specific styles */
 .btn-close {
-  display: none;
+    display: none;
 }
+
 [data-modal-open='true'] .btn-close {
-  display: block;
+    display: block;
 }
 
 .asset-selector img {
-  display: none;
+    display: none;
 }
 
 .asset-selector .btn-remove-asset {
-  display: none;
+    display: none;
 }
 
 .asset-selector.selected img {
-  display: inline-block;
+    display: inline-block;
 }
 
 .asset-selected.selected .btn-remove-asset {
-  display: inline-block;
+    display: inline-block;
 }
 
 .asset-selected.selected .btn-select-asset {
-  display: none;
+    display: none;
 }
+
 /* #endregion */

--- a/packages/cli/templates/react/src/components/FieldPluginExample/example.css
+++ b/packages/cli/templates/react/src/components/FieldPluginExample/example.css
@@ -1,78 +1,78 @@
 /*Layout Styles*/
 .container {
-  max-width: 22rem;
-  margin: 0 auto;
-  background-color: #ffffff;
-  border: 1px solid var(--light);
-  padding: 15px;
-  border-radius: 5px;
+    max-width: 22rem;
+    margin: 0 auto;
+    background-color: #ffffff;
+    border: 1px solid var(--light);
+    padding: 15px;
+    border-radius: 5px;
 }
 
 h2 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  font-weight: 500;
-  margin: 1rem 0;
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+    font-weight: 500;
+    margin: 1rem 0;
 }
 
 hr {
-  border-top: 1px dashed var(--light);
-  border-bottom: 0;
-  border-left: 0;
-  border-right: 0;
-  margin: 1.25rem 0;
+    border-top: 1px dashed var(--light);
+    border-bottom: 0;
+    border-left: 0;
+    border-right: 0;
+    margin: 1.25rem 0;
 }
 
 .counter-value {
-  margin-top: 1.25rem;
-  margin-bottom: 1rem;
-  font-size: 1.625rem;
-  font-weight: 700;
-  text-align: center;
+    margin-top: 1.25rem;
+    margin-bottom: 1rem;
+    font-size: 1.625rem;
+    font-weight: 700;
+    text-align: center;
 }
 
 .btn {
-  font-size: 0.875rem;
-  font-weight: 500;
-  padding: 0.8125rem 1rem;
-  background: transparent;
-  border: 1px solid var(--light);
-  border-radius: 0.3125rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease-in-out;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.8125rem 1rem;
+    background: transparent;
+    border: 1px solid var(--light);
+    border-radius: 0.3125rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out;
 }
 
 .w-full {
-  width: 100%;
+    width: 100%;
 }
 
 .btn:hover {
-  background-color: var(--light_75);
+    background-color: var(--light_75);
 }
 
 .btn-close {
-  position: absolute;
-  top: 0;
-  right: 0;
-  border: 0;
+    position: fixed;
+    top: 0;
+    right: 0;
+    border: 0;
 }
 
 .btn-close:hover {
-  background-color: var(--light_75);
+    background-color: var(--light_75);
 }
 
 .asset-selector img {
-  width: 100%;
-  display: block;
-  margin-bottom: 1rem;
+    width: 100%;
+    display: block;
+    margin-bottom: 1rem;
 }
 
 .sr-only {
-  position: absolute !important;
-  clip: rect(1px, 1px, 1px, 1px);
-  padding: 0 !important;
-  border: 0 !important;
-  height: 1px !important;
-  width: 1px !important;
-  overflow: hidden;
+    position: absolute !important;
+    clip: rect(1px, 1px, 1px, 1px);
+    padding: 0 !important;
+    border: 0 !important;
+    height: 1px !important;
+    width: 1px !important;
+    overflow: hidden;
 }

--- a/packages/cli/templates/react/src/components/FieldPluginExample/example.css
+++ b/packages/cli/templates/react/src/components/FieldPluginExample/example.css
@@ -1,78 +1,78 @@
 /*Layout Styles*/
 .container {
-    max-width: 22rem;
-    margin: 0 auto;
-    background-color: #ffffff;
-    border: 1px solid var(--light);
-    padding: 15px;
-    border-radius: 5px;
+  max-width: 22rem;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border: 1px solid var(--light);
+  padding: 15px;
+  border-radius: 5px;
 }
 
 h2 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-    font-weight: 500;
-    margin: 1rem 0;
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  font-weight: 500;
+  margin: 1rem 0;
 }
 
 hr {
-    border-top: 1px dashed var(--light);
-    border-bottom: 0;
-    border-left: 0;
-    border-right: 0;
-    margin: 1.25rem 0;
+  border-top: 1px dashed var(--light);
+  border-bottom: 0;
+  border-left: 0;
+  border-right: 0;
+  margin: 1.25rem 0;
 }
 
 .counter-value {
-    margin-top: 1.25rem;
-    margin-bottom: 1rem;
-    font-size: 1.625rem;
-    font-weight: 700;
-    text-align: center;
+  margin-top: 1.25rem;
+  margin-bottom: 1rem;
+  font-size: 1.625rem;
+  font-weight: 700;
+  text-align: center;
 }
 
 .btn {
-    font-size: 0.875rem;
-    font-weight: 500;
-    padding: 0.8125rem 1rem;
-    background: transparent;
-    border: 1px solid var(--light);
-    border-radius: 0.3125rem;
-    cursor: pointer;
-    transition: background-color 0.2s ease-in-out;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.8125rem 1rem;
+  background: transparent;
+  border: 1px solid var(--light);
+  border-radius: 0.3125rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
 }
 
 .w-full {
-    width: 100%;
+  width: 100%;
 }
 
 .btn:hover {
-    background-color: var(--light_75);
+  background-color: var(--light_75);
 }
 
 .btn-close {
-    position: fixed;
-    top: 0;
-    right: 0;
-    border: 0;
+  position: fixed;
+  top: 0;
+  right: 0;
+  border: 0;
 }
 
 .btn-close:hover {
-    background-color: var(--light_75);
+  background-color: var(--light_75);
 }
 
 .asset-selector img {
-    width: 100%;
-    display: block;
-    margin-bottom: 1rem;
+  width: 100%;
+  display: block;
+  margin-bottom: 1rem;
 }
 
 .sr-only {
-    position: absolute !important;
-    clip: rect(1px, 1px, 1px, 1px);
-    padding: 0 !important;
-    border: 0 !important;
-    height: 1px !important;
-    width: 1px !important;
-    overflow: hidden;
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0 !important;
+  border: 0 !important;
+  height: 1px !important;
+  width: 1px !important;
+  overflow: hidden;
 }

--- a/packages/cli/templates/react/src/style.css
+++ b/packages/cli/templates/react/src/style.css
@@ -1,69 +1,68 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
 html {
-    overflow: auto;
-    height: 100%;
+  overflow: auto;
+  height: 100%;
 }
 
 :root {
-    /*Storyblok colors*/
-    --sb_green: #00b3b0;
-    --sb_green_75: #40c6c4;
-    --sb_green_50: #7fd9d7;
-    --sb_green_25: #d9f4f3;
-    --sb_dark_blue: #1b243f;
-    --sb_dark_blue_75: #545b6f;
-    --sb_dark_blue_50: #8d919f;
-    --sb_dark_blue_25: #c6c8cf;
-    --green: #2db47d;
-    --green_75: #62c79e;
-    --green_50: #96d9be;
-    --green_25: #caecde;
-    --green_disabled: #004e4c;
-    --yellow: #fbce41;
-    --yellow_75: #fcdb71;
-    --yellow_50: #fde6a0;
-    --yellow_25: #fef3cf;
-    --blue: #395ece;
-    --blue_75: #6b87db;
-    --blue_50: #9caee6;
-    --blue_25: #cdd7f3;
-    --orange: #ffac00;
-    --orange_75: #ffc140;
-    --orange_50: #ffd57f;
-    --orange_25: #ffeabf;
-    --red: #ff6159;
-    --red_75: #ff8983;
-    --red_50: #ffb0ac;
-    --red_25: #ffd7d5;
-    --light: #dfe3e8;
-    --light_75: #e7eaee;
-    --light_50: #eff1f3;
-    --light_25: #f7f8f9;
-    --light_gray: #b1b5be;
-    --black: #101525;
-    --white: #fff;
+  /*Storyblok colors*/
+  --sb_green: #00b3b0;
+  --sb_green_75: #40c6c4;
+  --sb_green_50: #7fd9d7;
+  --sb_green_25: #d9f4f3;
+  --sb_dark_blue: #1b243f;
+  --sb_dark_blue_75: #545b6f;
+  --sb_dark_blue_50: #8d919f;
+  --sb_dark_blue_25: #c6c8cf;
+  --green: #2db47d;
+  --green_75: #62c79e;
+  --green_50: #96d9be;
+  --green_25: #caecde;
+  --green_disabled: #004e4c;
+  --yellow: #fbce41;
+  --yellow_75: #fcdb71;
+  --yellow_50: #fde6a0;
+  --yellow_25: #fef3cf;
+  --blue: #395ece;
+  --blue_75: #6b87db;
+  --blue_50: #9caee6;
+  --blue_25: #cdd7f3;
+  --orange: #ffac00;
+  --orange_75: #ffc140;
+  --orange_50: #ffd57f;
+  --orange_25: #ffeabf;
+  --red: #ff6159;
+  --red_75: #ff8983;
+  --red_50: #ffb0ac;
+  --red_25: #ffd7d5;
+  --light: #dfe3e8;
+  --light_75: #e7eaee;
+  --light_50: #eff1f3;
+  --light_25: #f7f8f9;
+  --light_gray: #b1b5be;
+  --black: #101525;
+  --white: #fff;
 
-    font-family: 'Roboto', sans-serif;
-    font-style: normal;
-    line-height: 1.5;
-    font-weight: 400;
-    font-size: 1rem;
-    font-synthesis: none;
-    text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-text-size-adjust: 100%;
+  font-family: 'Roboto', sans-serif;
+  font-style: normal;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 1rem;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
 }
 
 #app {
-    width: 100%;
-    height: 100%;
+  width: 100%;
 }
 
 /*Element Styles*/
 body {
-    margin: 0;
-    display: flex;
-    box-sizing: border-box;
+  margin: 0;
+  display: flex;
+  box-sizing: border-box;
 }

--- a/packages/cli/templates/react/src/style.css
+++ b/packages/cli/templates/react/src/style.css
@@ -1,67 +1,69 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
 html {
-  overflow: hidden;
+    overflow: auto;
+    height: 100%;
 }
 
 :root {
-  /*Storyblok colors*/
-  --sb_green: #00b3b0;
-  --sb_green_75: #40c6c4;
-  --sb_green_50: #7fd9d7;
-  --sb_green_25: #d9f4f3;
-  --sb_dark_blue: #1b243f;
-  --sb_dark_blue_75: #545b6f;
-  --sb_dark_blue_50: #8d919f;
-  --sb_dark_blue_25: #c6c8cf;
-  --green: #2db47d;
-  --green_75: #62c79e;
-  --green_50: #96d9be;
-  --green_25: #caecde;
-  --green_disabled: #004e4c;
-  --yellow: #fbce41;
-  --yellow_75: #fcdb71;
-  --yellow_50: #fde6a0;
-  --yellow_25: #fef3cf;
-  --blue: #395ece;
-  --blue_75: #6b87db;
-  --blue_50: #9caee6;
-  --blue_25: #cdd7f3;
-  --orange: #ffac00;
-  --orange_75: #ffc140;
-  --orange_50: #ffd57f;
-  --orange_25: #ffeabf;
-  --red: #ff6159;
-  --red_75: #ff8983;
-  --red_50: #ffb0ac;
-  --red_25: #ffd7d5;
-  --light: #dfe3e8;
-  --light_75: #e7eaee;
-  --light_50: #eff1f3;
-  --light_25: #f7f8f9;
-  --light_gray: #b1b5be;
-  --black: #101525;
-  --white: #fff;
+    /*Storyblok colors*/
+    --sb_green: #00b3b0;
+    --sb_green_75: #40c6c4;
+    --sb_green_50: #7fd9d7;
+    --sb_green_25: #d9f4f3;
+    --sb_dark_blue: #1b243f;
+    --sb_dark_blue_75: #545b6f;
+    --sb_dark_blue_50: #8d919f;
+    --sb_dark_blue_25: #c6c8cf;
+    --green: #2db47d;
+    --green_75: #62c79e;
+    --green_50: #96d9be;
+    --green_25: #caecde;
+    --green_disabled: #004e4c;
+    --yellow: #fbce41;
+    --yellow_75: #fcdb71;
+    --yellow_50: #fde6a0;
+    --yellow_25: #fef3cf;
+    --blue: #395ece;
+    --blue_75: #6b87db;
+    --blue_50: #9caee6;
+    --blue_25: #cdd7f3;
+    --orange: #ffac00;
+    --orange_75: #ffc140;
+    --orange_50: #ffd57f;
+    --orange_25: #ffeabf;
+    --red: #ff6159;
+    --red_75: #ff8983;
+    --red_50: #ffb0ac;
+    --red_25: #ffd7d5;
+    --light: #dfe3e8;
+    --light_75: #e7eaee;
+    --light_50: #eff1f3;
+    --light_25: #f7f8f9;
+    --light_gray: #b1b5be;
+    --black: #101525;
+    --white: #fff;
 
-  font-family: 'Roboto', sans-serif;
-  font-style: normal;
-  line-height: 1.5;
-  font-weight: 400;
-  font-size: 1rem;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
+    font-family: 'Roboto', sans-serif;
+    font-style: normal;
+    line-height: 1.5;
+    font-weight: 400;
+    font-size: 1rem;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-text-size-adjust: 100%;
 }
 
 #app {
-  width: 100%;
+    width: 100%;
+    height: 100%;
 }
 
 /*Element Styles*/
 body {
-  margin: 0;
-  display: flex;
-  box-sizing: border-box;
+    margin: 0;
+    display: flex;
+    box-sizing: border-box;
 }

--- a/packages/cli/templates/vue2/src/components/FieldPluginExample/example.css
+++ b/packages/cli/templates/vue2/src/components/FieldPluginExample/example.css
@@ -51,7 +51,7 @@ hr {
 }
 
 .btn-close {
-  position: absolute;
+  position: fixed;
   top: 0;
   right: 0;
   border: 0;

--- a/packages/cli/templates/vue2/src/style.css
+++ b/packages/cli/templates/vue2/src/style.css
@@ -1,7 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
 html {
-  overflow: hidden;
+  overflow: auto;
+  hegiht: 100%;
 }
 
 :root {

--- a/packages/cli/templates/vue2/src/style.css
+++ b/packages/cli/templates/vue2/src/style.css
@@ -2,7 +2,7 @@
 
 html {
   overflow: auto;
-  hegiht: 100%;
+  height: 100%;
 }
 
 :root {

--- a/packages/cli/templates/vue3/src/components/FieldPluginExample/example.css
+++ b/packages/cli/templates/vue3/src/components/FieldPluginExample/example.css
@@ -51,7 +51,7 @@ hr {
 }
 
 .btn-close {
-  position: absolute;
+  position: fixed;
   top: 0;
   right: 0;
   border: 0;

--- a/packages/cli/templates/vue3/src/style.css
+++ b/packages/cli/templates/vue3/src/style.css
@@ -1,7 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
 html {
-  overflow: hidden;
+  overflow: auto;
+  height: 100%;
 }
 
 :root {


### PR DESCRIPTION
## What?
Resizing of the field plugin UI inside the iFrame has changed and been release in the previous sprint. 
Now once the plugin is loaded it sends a property to the Storyblok App --> `modalFullHeight: true`.
This property signals to the Container that in case the modal is open, the iframe should add `size=auto` inside the inline styles.

By adding this option, it should be easier for the user to create sticky headers and footers. Before there have been issues where such designs were not easily possible. This PR adds some styles to enable this feature. 

In the following video, I demonstrate the new possible implementation. The div with green background is sticky to top. The red div is sticky to bottom. 

https://www.loom.com/share/5cc5211c2ec6491c887ec1b78ad82336

## Why?

[JIRA: EXT-1926](https://storyblok.atlassian.net/browse/EXT-1926)

## How to test? (optional)
As the new functionality where the field plugin sends the new modalFullHeight property to the container, you need to run it locally and connect the local version of the field plugin to your template.

1. Rebuild field-plugin package --> cd packages/field-plugin && yarn build
2. Replacing dependency inside the react template to "@storyblok/field-plugin": "workspace:*"
3. cd into React Template and run --> yarn install && yarn dev

Then open the Partner Portal and go to the Field Plugin Development Environment.