### PR TITLE
fix(cli): add logic to handle a case where CI is setting an env variable

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -63,78 +63,41 @@ export const getPersonalAccessToken: GetPersonalAccessTokenFunc = async ({
   dotEnvPath,
   skipPrompts,
 }) => {
-  if (typeof token !== 'undefined' && token !== '') {
+  if (isToken(token)) {
     return {
       token,
     }
   }
 
-  const pathsToLoad =
-    typeof dotEnvPath === 'string' ? [dotEnvPath] : ['.env', '.env.local']
-
-  const noneOfThemExists = pathsToLoad.every(
-    (path: string) => !existsSync(path),
-  )
-  if (skipPrompts && noneOfThemExists) {
-    return {
-      error: true,
-      message: [
-        `Environment variable file doesn't exist at the following path:`,
-        ...pathsToLoad.map((path) => `  > ${resolve(path)}`),
-      ].join('\n'),
-    }
+  if (isToken(process.env.STORYBLOK_PERSONAL_ACCESS_TOKEN)) {
+    return { token: process.env.STORYBLOK_PERSONAL_ACCESS_TOKEN }
   }
 
-  pathsToLoad.forEach((path) => dotenv.config({ path }))
+  const defaultEnvPaths =
+    typeof dotEnvPath === 'string' ? [dotEnvPath] : ['.env', '.env.local']
 
-  const tokenFromEnvFiles = process.env.STORYBLOK_PERSONAL_ACCESS_TOKEN
-  if (typeof tokenFromEnvFiles !== 'undefined' && tokenFromEnvFiles !== '') {
+  const tokenFromEnvFiles = getTokenFromFiles(defaultEnvPaths)
+
+  if (tokenFromEnvFiles !== undefined) {
     return {
       token: tokenFromEnvFiles,
     }
   }
 
-  if (skipPrompts) {
+  if (tokenFromEnvFiles === undefined && skipPrompts) {
     return {
       error: true,
       message: [
-        `Could't find the environment variable \`STORYBLOK_PERSONAL_ACCESS_TOKEN\` at the following paths:`,
-        ...pathsToLoad.map((path) => `  > ${resolve(path)}`),
+        `Couldn't find the environment variable \`STORYBLOK_PERSONAL_ACCESS_TOKEN\` at the following paths:`,
+        ...defaultEnvPaths.map((path) => `  > ${resolve(path)}`),
       ].join('\n'),
     }
-  } else {
-    console.log(
-      cyan(bold('[info]')),
-      'Please enter your personal access token to deploy the field plugin.',
-    )
-    console.log('  > https://app.storyblok.com/#/me/account?tab=token')
-    console.log('')
-    const { token } = await betterPrompts<{ token: string }>({
-      type: 'text',
-      name: 'token',
-      message: 'Personal access token:',
-    })
-
-    console.log(
-      cyan(`Do you want to save this token in this file for future use?`),
-    )
-    console.log(`  > ${resolve(dotEnvPath ?? '.env.local')}`)
-    const { save } = await betterPrompts<{ save: boolean }>({
-      type: 'confirm',
-      name: 'save',
-      message: 'Save?',
-      initial: true,
-    })
-
-    if (save) {
-      appendFileSync(
-        dotEnvPath ?? '.env.local',
-        `\nSTORYBLOK_PERSONAL_ACCESS_TOKEN=${token}\n`,
-      )
-    }
-
-    return { token }
   }
+
+  const inputToken = await inputPersonalAccessToken()
+  await savePersonalAccessToken(inputToken, dotEnvPath)
+
+  return { token: inputToken }
 }
 
 export const isValidPackageName = (name: string | undefined): name is string =>
@@ -332,4 +295,75 @@ export const expandTilde = (folderPath: string) => {
     return homedir + folderPath.slice(1)
   }
   return folderPath
+}
+
+const getExistingEnvironmentFiles = (paths: string[]) =>
+  paths.reduce((acc: string[], path: string) => {
+    if (existsSync(path)) {
+      return [...acc, path]
+    }
+
+    return acc
+  }, [])
+
+const isToken = (token: unknown): token is string =>
+  token !== undefined &&
+  token !== null &&
+  typeof token === 'string' &&
+  token !== ''
+
+const inputPersonalAccessToken = async () => {
+  console.log(
+    cyan(bold('[info]')),
+    'Please enter your personal access token to deploy the field plugin.',
+  )
+  console.log('  > https://app.storyblok.com/#/me/account?tab=token')
+  console.log('')
+  const { token } = await betterPrompts<{ token: string }>({
+    type: 'text',
+    name: 'token',
+    message: 'Personal access token:',
+  })
+
+  return token
+}
+
+const savePersonalAccessToken = async (
+  token: string,
+  location?: string,
+): Promise<void> => {
+  console.log(
+    cyan(`Do you want to save this token in this file for future use?`),
+  )
+  console.log(`  > ${resolve(location ?? '.env.local')}`)
+  const { save } = await betterPrompts<{ save: boolean }>({
+    type: 'confirm',
+    name: 'save',
+    message: 'Save?',
+    initial: true,
+  })
+
+  if (save) {
+    appendFileSync(
+      location ?? '.env.local',
+      `\nSTORYBLOK_PERSONAL_ACCESS_TOKEN=${token}\n`,
+    )
+  }
+}
+const getTokenFromFiles = (envPaths: string[]): string | undefined => {
+  const envPathsToLoad = getExistingEnvironmentFiles(envPaths)
+
+  if (envPathsToLoad.length === 0) {
+    return undefined
+  }
+
+  envPathsToLoad.forEach((path) => dotenv.config({ path }))
+
+  const token = process.env.STORYBLOK_PERSONAL_ACCESS_TOKEN
+
+  if (!isToken(token)) {
+    return undefined
+  }
+
+  return token
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -63,13 +63,13 @@ export const getPersonalAccessToken: GetPersonalAccessTokenFunc = async ({
   dotEnvPath,
   skipPrompts,
 }) => {
-  if (isToken(token)) {
+  if (isTokenValid(token)) {
     return {
       token,
     }
   }
 
-  if (isToken(process.env.STORYBLOK_PERSONAL_ACCESS_TOKEN)) {
+  if (isTokenValid(process.env.STORYBLOK_PERSONAL_ACCESS_TOKEN)) {
     return { token: process.env.STORYBLOK_PERSONAL_ACCESS_TOKEN }
   }
 
@@ -84,7 +84,7 @@ export const getPersonalAccessToken: GetPersonalAccessTokenFunc = async ({
     }
   }
 
-  if (tokenFromEnvFiles === undefined && skipPrompts) {
+  if (skipPrompts) {
     return {
       error: true,
       message: [
@@ -306,7 +306,7 @@ const getExistingEnvironmentFiles = (paths: string[]) =>
     return acc
   }, [])
 
-const isToken = (token: unknown): token is string =>
+const isTokenValid = (token: unknown): token is string =>
   token !== undefined &&
   token !== null &&
   typeof token === 'string' &&
@@ -361,7 +361,7 @@ const getTokenFromFiles = (envPaths: string[]): string | undefined => {
 
   const token = process.env.STORYBLOK_PERSONAL_ACCESS_TOKEN
 
-  if (!isToken(token)) {
+  if (!isTokenValid(token)) {
     return undefined
   }
 


### PR DESCRIPTION
## What?
**Scope of the PR:**
- _Adding a new check_ to resolve an issue in case a an env variable is set inside GitHub action like this: 
```
- name: Deploy
   env:
     STORYBLOK_PERSONAL_ACCESS_TOKEN: ${{secrets.STORYBLOK_PERSONAL_ACCESS_TOKEN}}
   run: yarn workspace commerce-layer deploy --skipPrompts

```

- _Refactoring_ `getPersonalAccessToken()` function to make it more clear and readable.

TODO: 
- [ ] Adding this new way of call deploy command inside the README.md


## Why?
You can find a more detailed description inside JIRA: [EXT-2013](https://storyblok.atlassian.net/browse/EXT-2013)

[EXT-2013]: https://storyblok.atlassian.net/browse/EXT-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ