### PR TITLE
feat(lib): add validateContent (renamed from parseContent)

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -49,7 +49,7 @@ describe('utils', () => {
       expect(result).toEqual({
         error: true,
         message:
-          "Environment variable file doesn't exist at the following path:" +
+          "Couldn't find the environment variable `STORYBLOK_PERSONAL_ACCESS_TOKEN` at the following paths:" +
           '\n  > <current-directory>/.env.local',
       })
     })
@@ -67,7 +67,7 @@ describe('utils', () => {
         expect(result).toEqual({
           error: true,
           message:
-            "Could't find the environment variable `STORYBLOK_PERSONAL_ACCESS_TOKEN` at the following paths:" +
+            "Couldn't find the environment variable `STORYBLOK_PERSONAL_ACCESS_TOKEN` at the following paths:" +
             '\n  > <current-directory>/.env.local',
         })
       })
@@ -100,7 +100,7 @@ describe('utils', () => {
         expect(result).toEqual({
           error: true,
           message:
-            "Could't find the environment variable `STORYBLOK_PERSONAL_ACCESS_TOKEN` at the following paths:" +
+            "Couldn't find the environment variable `STORYBLOK_PERSONAL_ACCESS_TOKEN` at the following paths:" +
             '\n  > <current-directory>/.env' +
             '\n  > <current-directory>/.env.local',
         })

--- a/packages/cli/templates/js/src/main.js
+++ b/packages/cli/templates/js/src/main.js
@@ -15,7 +15,9 @@ let previousType = 'loading'
 
 // Establish communication with the Visual Editor
 createFieldPlugin({
-  parseContent: (content) => (typeof content === 'number' ? content : 0),
+  validateContent: (content) => ({
+    content: typeof content === 'number' ? content : 0,
+  }),
   onUpdateState: (response) => {
     // Re-render the button element when messages
     const { data, actions, type } = response

--- a/packages/cli/templates/react/src/components/FieldPlugin.tsx
+++ b/packages/cli/templates/react/src/components/FieldPlugin.tsx
@@ -2,9 +2,7 @@ import { FunctionComponent } from 'react'
 import { useFieldPlugin } from '@storyblok/field-plugin/react'
 
 const FieldPlugin: FunctionComponent = () => {
-  const plugin = useFieldPlugin({
-    parseContent: (content: unknown) => content,
-  })
+  const plugin = useFieldPlugin()
 
   return <pre>{JSON.stringify(plugin, null, 2)}</pre>
 }

--- a/packages/cli/templates/react/src/components/FieldPlugin.tsx
+++ b/packages/cli/templates/react/src/components/FieldPlugin.tsx
@@ -2,7 +2,27 @@ import { FunctionComponent } from 'react'
 import { useFieldPlugin } from '@storyblok/field-plugin/react'
 
 const FieldPlugin: FunctionComponent = () => {
-  const plugin = useFieldPlugin()
+  const plugin = useFieldPlugin({
+    /*
+    The `validateContent` parameter is optional. It allows you to
+      - validate the content
+      - make changes before sending it to the Storyblok Visual Editor
+      - provide type-safety
+
+    validateContent: (content: unknown) => {
+      if (typeof content === 'string') {
+        return {
+          content,
+        }
+      } else {
+        return {
+          content,
+          error: `content is expected to be a string (actual: ${JSON.stringify(content)})`,
+        }
+      }
+    }
+    */
+  })
 
   return <pre>{JSON.stringify(plugin, null, 2)}</pre>
 }

--- a/packages/cli/templates/react/src/components/FieldPlugin.tsx
+++ b/packages/cli/templates/react/src/components/FieldPlugin.tsx
@@ -9,6 +9,7 @@ const FieldPlugin: FunctionComponent = () => {
       - make changes before sending it to the Storyblok Visual Editor
       - provide type-safety
 
+    // For example,
     validateContent: (content: unknown) => {
       if (typeof content === 'string') {
         return {
@@ -17,7 +18,7 @@ const FieldPlugin: FunctionComponent = () => {
       } else {
         return {
           content,
-          error: `content is expected to be a string (actual: ${JSON.stringify(content)})`,
+          error: `content is expected to be a string (actual value: ${JSON.stringify(content)})`,
         }
       }
     }

--- a/packages/cli/templates/react/src/components/FieldPluginExample/index.tsx
+++ b/packages/cli/templates/react/src/components/FieldPluginExample/index.tsx
@@ -7,8 +7,9 @@ import { useFieldPlugin } from '@storyblok/field-plugin/react'
 
 const FieldPlugin: FunctionComponent = () => {
   const { type, data, actions } = useFieldPlugin({
-    parseContent: (content: unknown) =>
-      typeof content === 'number' ? content : 0,
+    validateContent: (content: unknown) => ({
+      content: typeof content === 'number' ? content : 0,
+    }),
   })
 
   if (type !== 'loaded') {

--- a/packages/cli/templates/vue2/src/fieldPlugin.js
+++ b/packages/cli/templates/vue2/src/fieldPlugin.js
@@ -5,7 +5,9 @@ import { createFieldPlugin } from '@storyblok/field-plugin'
 export const fieldPluginMixin = {
   created() {
     createFieldPlugin({
-      parseContent: (content) => (typeof content === 'number' ? content : 0),
+      validateContent: (content) => ({
+        content: typeof content === 'number' ? content : 0,
+      }),
       onUpdateState: (newState) => {
         Vue.set(this.plugin, 'type', newState.type)
         Vue.set(this.plugin, 'error', newState.error)

--- a/packages/cli/templates/vue3/src/components/FieldPlugin.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPlugin.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useFieldPlugin } from '@storyblok/field-plugin/vue3'
 
-const plugin = useFieldPlugin({ parseContent: (content: unknown) => content })
+const plugin = useFieldPlugin()
 </script>
 
 <template>

--- a/packages/cli/templates/vue3/src/components/FieldPlugin.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPlugin.vue
@@ -1,7 +1,27 @@
 <script setup lang="ts">
 import { useFieldPlugin } from '@storyblok/field-plugin/vue3'
 
-const plugin = useFieldPlugin()
+const plugin = useFieldPlugin({
+  /*
+    The `validateContent` parameter is optional. It allows you to
+      - validate the content
+      - make changes before sending it to the Storyblok Visual Editor
+      - provide type-safety
+
+    validateContent: (content: unknown) => {
+      if (typeof content === 'string') {
+        return {
+          content,
+        }
+      } else {
+        return {
+          content,
+          error: `content is expected to be a string (actual: ${JSON.stringify(content)})`,
+        }
+      }
+    }
+  */
+})
 </script>
 
 <template>

--- a/packages/cli/templates/vue3/src/components/FieldPlugin.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPlugin.vue
@@ -8,6 +8,7 @@ const plugin = useFieldPlugin({
       - make changes before sending it to the Storyblok Visual Editor
       - provide type-safety
 
+    // For example,
     validateContent: (content: unknown) => {
       if (typeof content === 'string') {
         return {
@@ -16,7 +17,7 @@ const plugin = useFieldPlugin({
       } else {
         return {
           content,
-          error: `content is expected to be a string (actual: ${JSON.stringify(content)})`,
+          error: `content is expected to be a string (actual value: ${JSON.stringify(content)})`,
         }
       }
     }

--- a/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
@@ -6,8 +6,9 @@ import AssetSelector from './AssetSelector.vue'
 import { useFieldPlugin } from '@storyblok/field-plugin/vue3'
 
 const plugin = useFieldPlugin({
-  parseContent: (content: unknown) =>
-    typeof content === 'number' ? content : 0,
+  validateContent: (content: unknown) => ({
+    content: typeof content === 'number' ? content : 0,
+  }),
 })
 
 function closeModal() {

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -6,9 +6,10 @@ import { useFieldPlugin } from '@storyblok/field-plugin/react'
 import { ModalView } from './ModalView'
 import { NonModalView } from './NonModalView'
 
-const parseContent = (content: unknown) =>
-  typeof content === 'number' ? content : 0
-type Content = ReturnType<typeof parseContent>
+const validateContent = (content: unknown) => ({
+  content: typeof content === 'number' ? content : 0,
+})
+type Content = ReturnType<typeof validateContent>['content']
 
 export type PluginComponent = FunctionComponent<{
   data: FieldPluginData<Content>
@@ -17,7 +18,7 @@ export type PluginComponent = FunctionComponent<{
 
 export const FieldPluginDemo: FunctionComponent = () => {
   const { type, data, actions } = useFieldPlugin({
-    parseContent,
+    validateContent,
   })
 
   if (type === 'loading') {

--- a/packages/field-plugin/helpers/react/src/useFieldPlugin.ts
+++ b/packages/field-plugin/helpers/react/src/useFieldPlugin.ts
@@ -10,7 +10,7 @@ export const useFieldPlugin = <Content>({
 }: Omit<
   CreateFieldPluginOptions<Content>,
   'onUpdateState'
->): FieldPluginResponse<Content> => {
+> = {}): FieldPluginResponse<Content> => {
   const [plugin, setPlugin] = useState<FieldPluginResponse<Content>>({
     type: 'loading',
   })

--- a/packages/field-plugin/helpers/react/src/useFieldPlugin.ts
+++ b/packages/field-plugin/helpers/react/src/useFieldPlugin.ts
@@ -6,7 +6,7 @@ import {
 import { useEffect, useState } from 'react'
 
 export const useFieldPlugin = <Content>({
-  parseContent,
+  validateContent,
 }: Omit<
   CreateFieldPluginOptions<Content>,
   'onUpdateState'
@@ -31,7 +31,7 @@ export const useFieldPlugin = <Content>({
           })
         }
       },
-      parseContent,
+      validateContent,
     })
   }, [])
 

--- a/packages/field-plugin/helpers/vue3/src/useFieldPlugin.ts
+++ b/packages/field-plugin/helpers/vue3/src/useFieldPlugin.ts
@@ -22,7 +22,7 @@ const updateObjectWithoutChangingReference = (
 }
 
 export const useFieldPlugin = <Content>({
-  parseContent,
+  validateContent,
 }: Omit<CreateFieldPluginOptions<Content>, 'onUpdateState'>): UnwrapRef<
   FieldPluginResponse<Content>
 > => {
@@ -88,7 +88,7 @@ export const useFieldPlugin = <Content>({
           return
         }
       },
-      parseContent,
+      validateContent,
     })
   })
 

--- a/packages/field-plugin/helpers/vue3/src/useFieldPlugin.ts
+++ b/packages/field-plugin/helpers/vue3/src/useFieldPlugin.ts
@@ -23,7 +23,7 @@ const updateObjectWithoutChangingReference = (
 
 export const useFieldPlugin = <Content>({
   validateContent,
-}: Omit<CreateFieldPluginOptions<Content>, 'onUpdateState'>): UnwrapRef<
+}: Omit<CreateFieldPluginOptions<Content>, 'onUpdateState'> = {}): UnwrapRef<
   FieldPluginResponse<Content>
 > => {
   const plugin = reactive<FieldPluginResponse<Content>>({

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -1,4 +1,4 @@
-import { createPluginActions } from './createPluginActions'
+import { createPluginActions, ValidateContent } from './createPluginActions'
 import { createHeightChangeListener } from './createHeightChangeListener'
 import { disableDefaultStoryblokStyles } from './disableDefaultStoryblokStyles'
 import { pluginUrlParamsFromUrl } from '../messaging'
@@ -9,10 +9,7 @@ import { isCloneable } from '../utils/isCloneable'
 
 export type CreateFieldPluginOptions<Content> = {
   onUpdateState: (state: FieldPluginResponse<Content>) => void
-  validateContent?: (content: unknown) => {
-    content: Content
-    error?: string
-  }
+  validateContent?: ValidateContent<Content>
 }
 
 export type CreateFieldPlugin = <Content = unknown>(

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
@@ -31,7 +31,9 @@ const wait = async (ms: number) => {
   })
 }
 
-const parseContent = (content: unknown) => content
+const validateContent = (content: unknown) => ({
+  content,
+})
 
 describe('createPluginActions', () => {
   describe('initial call', () => {
@@ -41,7 +43,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       expect(postToContainer).not.toHaveBeenCalled()
     })
@@ -53,7 +55,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       const randomString = '3490ruieo4jf984ej89q32jd0i2k3w09k3902'
       onLoaded({
@@ -85,7 +87,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       setModalOpen(false)
 
@@ -110,7 +112,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       setModalOpen(false)
 
@@ -139,7 +141,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       const content = '409fjk340wo9jkc0954ij0943iu09c43*&(YT-0c43'
       setContent(content)
@@ -157,7 +159,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       const content = '0932ui2foiuerhjv98453jeh09c34jwk-0c43'
       setContent(content)
@@ -178,7 +180,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       requestContext()
       expect(postToContainer).toHaveBeenLastCalledWith(
@@ -197,7 +199,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       selectAsset()
@@ -216,7 +218,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       const promise = selectAsset()
       const filename = 'hello.jpg'
@@ -240,7 +242,7 @@ describe('createPluginActions', () => {
         uid,
         postToContainer,
         onUpdateState,
-        parseContent,
+        validateContent,
       })
       const promise = selectAsset()
       const filename = 'hello.jpg'

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -19,14 +19,16 @@ import { FieldPluginActions, Initialize } from '../FieldPluginActions'
 import { pluginStateFromStateChangeMessage } from './partialPluginStateFromStateChangeMessage'
 import { callbackQueue } from './callbackQueue'
 
+export type ValidateContent<Content> = (content: unknown) => {
+  content: Content
+  error?: string
+}
+
 export type CreatePluginActions = <Content>(options: {
   uid: string
   postToContainer: (message: unknown) => void
   onUpdateState: (state: FieldPluginData<Content>) => void
-  validateContent: (content: unknown) => {
-    content: Content
-    error?: string
-  }
+  validateContent: ValidateContent<Content>
 }) => {
   // These functions are to be called by the field plugin when the user performs actions in the UI
   actions: FieldPluginActions<Content>

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
@@ -13,10 +13,11 @@ export const pluginStateFromStateChangeMessage = <Content>(
   },
 ): FieldPluginData<Content> => {
   const validateResult = validateContent(message.model)
-  if ('error' in validateResult) {
+  if ('error' in validateResult && typeof validateResult.error === 'string') {
     console.warn(
       `[Warning] The provided content is not valid, but it's still sent to the Visual Editor.`,
     )
+    console.warn(`  > ${validateResult.error}`)
   }
 
   return {

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
@@ -7,16 +7,28 @@ import {
 
 export const pluginStateFromStateChangeMessage = <Content>(
   message: LoadedMessage | StateChangedMessage,
-  parseContent: (content: unknown) => Content,
-): FieldPluginData<Content> => ({
-  spaceId: message.spaceId ?? undefined,
-  story: message.story ?? undefined,
-  storyId: message.storyId ?? undefined,
-  storyLang: message.language === '' ? 'default' : message.language,
-  blockUid: message.blockId ?? undefined,
-  token: message.token ?? undefined,
-  options: recordFromFieldPluginOptions(message.schema.options),
-  uid: message.uid ?? undefined,
-  content: parseContent(message.model),
-  isModalOpen: message.isModalOpen,
-})
+  validateContent: (content: unknown) => {
+    content: Content
+    error?: string
+  },
+): FieldPluginData<Content> => {
+  const validateResult = validateContent(message.model)
+  if ('error' in validateResult) {
+    console.warn(
+      `[Warning] The provided content is not valid, but it's still sent to the Visual Editor.`,
+    )
+  }
+
+  return {
+    spaceId: message.spaceId ?? undefined,
+    story: message.story ?? undefined,
+    storyId: message.storyId ?? undefined,
+    storyLang: message.language === '' ? 'default' : message.language,
+    blockUid: message.blockId ?? undefined,
+    token: message.token ?? undefined,
+    options: recordFromFieldPluginOptions(message.schema.options),
+    uid: message.uid ?? undefined,
+    content: validateResult.content,
+    isModalOpen: message.isModalOpen,
+  }
+}


### PR DESCRIPTION
## What?

This PR adds `validateContent` to `createFieldPlugin()` function as a parameter.

- renamed from `parseContent`
- returns validation result (error if invalid)
- optional now (used to be required)
- prints out a warning message if the content is invalid

## Why?

While we don't have a way on the Visual Editor to prevent from saving invalid custom field plugin data, this pull request is the first step towards it by letting people define their validation logic.

This `validateContent` enables users to
1. send valid / invalid status and the error message to the Visual Editor
2. bring better type-safety

The Visual Editor will later use (1) to properly display the error message and prevent from saving invalid data.

(2) was still here since `parseContent`, to be clear.

Also, we're making `validateContent` here optional. `parseContent` used to be a required parameter. It's understandable that going from required -> optional is easy while optional -> required means a breaking change. However, having the parameter required raises the initial learning curve. If they need, they can just add it. And, do we ever want to make "optional -> required" breaking change? Not too sure. Literally we cannot think of any case where we mandate this parameter. If such situation happens, we will introduce the breaking change and bump the major version. Not that big of a deal for users, too.

JIRA: EXT-1987

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->