### PR TITLE
fix(cli): replace __dirname

### DIFF
--- a/packages/cli/config.ts
+++ b/packages/cli/config.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'path'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
 
 export const TEMPLATES = [
   {
@@ -35,10 +36,11 @@ export const TEMPLATES = [
   
   If we move this file to another folder, then we need to put correct value conditionally to `TEMPLATES_PATH`.
 */
-export const TEMPLATES_PATH = resolve(__dirname, 'templates')
+const currentDirectory = dirname(fileURLToPath(import.meta.url))
+export const TEMPLATES_PATH = resolve(currentDirectory, 'templates')
 
 export const MONOREPO_TEMPLATE_PATH = resolve(
-  __dirname,
+  currentDirectory,
   'templates',
   'monorepo',
 )

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -5,6 +5,7 @@ const externalDependencies = [
   'fs',
   'path',
   'os',
+  'url',
   ...Object.keys(pkg.dependencies),
 ]
 


### PR DESCRIPTION
## What?

This PR replaces `__dirname` with something else.

## Why?

I ran `yarn bump-version`, but got this error:

```
➜ yarn bump-version
/Users/eunjae/workspace/field-plugin/packages/cli/config.ts:38
export const TEMPLATES_PATH = resolve(__dirname, 'templates')
                                      ^


ReferenceError: __dirname is not defined in ES module scope
    at <anonymous> (/Users/eunjae/workspace/field-plugin/packages/cli/config.ts:38:39)
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)

Node.js v18.16.0
```

I'm not sure if I understand this issue 100% exactly. From my understanding, our library and the CLI gets transpiled to CJS. So using `__dirname` doesn't cause any problem.

However, when running `bump-version.ts`, it's run in ESM scope. And `__dirname` doesn't exist there. To work around this issue, we're not using `__dirname` any more, and replace it another way. However I didn't replace all the other `__dirname` occurrences in vite config files, and etc (that won't be executed in ESM scope).


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->