### PR TITLE
fix(cli): replace chalk with kleur

### DIFF
--- a/packages/field-plugin/helpers/vite/package.json
+++ b/packages/field-plugin/helpers/vite/package.json
@@ -14,6 +14,6 @@
     "vite-plugin-dts": "3.5.0"
   },
   "dependencies": {
-    "chalk": "5.3.0"
+    "kleur": "4.1.5"
   }
 }

--- a/packages/field-plugin/helpers/vite/src/utils/text.ts
+++ b/packages/field-plugin/helpers/vite/src/utils/text.ts
@@ -1,8 +1,1 @@
-import { Chalk } from 'chalk'
-
-const chalk = new Chalk({ level: 1 })
-
-export const green = (text: string) => chalk.green(text)
-export const gray = (text: string) => chalk.gray(text)
-export const red = (text: string) => chalk.red(text)
-export const bold = (text: string) => chalk.bold(text)
+export { green, gray, red, bold } from 'kleur/colors'

--- a/packages/field-plugin/helpers/vite/vite.config.ts
+++ b/packages/field-plugin/helpers/vite/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: ['querystring', 'fs', 'path', 'kleur'],
+      external: ['querystring', 'fs', 'path'],
     },
   },
 })

--- a/packages/field-plugin/helpers/vite/vite.config.ts
+++ b/packages/field-plugin/helpers/vite/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: ['querystring', 'fs', 'path', 'chalk'],
+      external: ['querystring', 'fs', 'path', 'kleur'],
     },
   },
 })

--- a/scripts/dev-template.mjs
+++ b/scripts/dev-template.mjs
@@ -18,6 +18,9 @@ import { $ } from 'zx'
 import fs from 'fs/promises'
 import path from 'path'
 
+// eslint-disable-next-line functional/immutable-data
+process.env.FORCE_COLOR = '1'
+
 const template = process.argv[3]
 if (!template) {
   console.error('[ERROR] This script requires a template name as an argument.')
@@ -35,21 +38,21 @@ file = file.replace(
     alias: [{
       find: /^@storyblok\\/field-plugin$/,
       replacement: '${path.resolve(
-    __dirname,
-    '../packages/field-plugin/src/index.ts',
-  )}'
+        __dirname,
+        '../packages/field-plugin/src/index.ts',
+      )}'
     }, {
       find: /^@storyblok\\/field-plugin\\/vue3$/,
       replacement: '${path.resolve(
-    __dirname,
-    '../packages/field-plugin/helpers/vue3/src/index.ts',
-  )}'
+        __dirname,
+        '../packages/field-plugin/helpers/vue3/src/index.ts',
+      )}'
     }, {
       find: /^@storyblok\\/field-plugin\\/react$/,
       replacement: '${path.resolve(
-    __dirname,
-    '../packages/field-plugin/helpers/react/src/index.ts',
-  )}'
+        __dirname,
+        '../packages/field-plugin/helpers/react/src/index.ts',
+      )}'
     }]
   },
   plugins:`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,13 +3925,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:5.3.0, chalk@npm:^5.0.0, chalk@npm:^5.2.0":
-  version: 5.3.0
-  resolution: "chalk@npm:5.3.0"
-  checksum: 623922e077b7d1e9dedaea6f8b9e9352921f8ae3afe739132e0e00c275971bdd331268183b2628cf4ab1727c45ea1f28d7e24ac23ce1db1eb653c414ca8a5a80
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^2.0.0":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -3950,6 +3943,13 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^5.0.0, chalk@npm:^5.2.0":
+  version: 5.3.0
+  resolution: "chalk@npm:5.3.0"
+  checksum: 623922e077b7d1e9dedaea6f8b9e9352921f8ae3afe739132e0e00c275971bdd331268183b2628cf4ab1727c45ea1f28d7e24ac23ce1db1eb653c414ca8a5a80
   languageName: node
   linkType: hard
 
@@ -6305,7 +6305,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "helper-vite@workspace:packages/field-plugin/helpers/vite"
   dependencies:
-    chalk: 5.3.0
+    kleur: 4.1.5
     typescript: ^5.0.2
     vite: ^4.4.5
     vite-plugin-dts: 3.5.0


### PR DESCRIPTION
## What?

```
npx @storyblok/field-plugin-cli@rc
```

After creating a monorepo, I ran yarn workspace <package-name> dev and got this error message:


```
failed to load config from /Users/eunjae/sandbox/ext-1971/t1/packages/p1/vite.config.ts
error when starting dev server:
file:///Users/eunjae/sandbox/ext-1971/t1/node_modules/@storyblok/field-plugin/dist/vite/index.js:2
import { Chalk } from "chalk";
         ^^^^^
SyntaxError: Named export 'Chalk' not found. The requested module 'chalk' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'chalk';
const { Chalk } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)
```


There must be something wrong regarding ESM, but we are already successfully using another color library called kleur, so I’m going to replace chalk with kleur instead of digging into this issue.

## Why?

JIRA: EXT-2038

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->