### PR TITLE
feat(template): setup vitest for react template

### DIFF
--- a/packages/cli/templates/react/package.json
+++ b/packages/cli/templates/react/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "vitest",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
@@ -15,15 +16,19 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "6.1.4",
+    "@testing-library/react": "14.0.0",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "6.1.0",
     "@typescript-eslint/parser": "6.1.0",
-    "@vitejs/plugin-react": "^3.1.0",
+    "@vitejs/plugin-react": "^4.1.0",
     "eslint": "latest",
     "eslint-plugin-react": "7.30.0",
+    "jsdom": "22.1.0",
     "typescript": "5.1.6",
     "vite": "^4.2.2",
-    "vite-plugin-css-injected-by-js": "3.1.0"
+    "vite-plugin-css-injected-by-js": "3.1.0",
+    "vitest": "0.34.6"
   }
 }

--- a/packages/cli/templates/react/src/components/FieldPluginExample/index.spec.tsx
+++ b/packages/cli/templates/react/src/components/FieldPluginExample/index.spec.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { describe, test, expect, vi } from 'vitest'
+
+import FieldPlugin from '.'
+import { useFieldPlugin } from '@storyblok/field-plugin/react'
+import { FieldPluginResponse } from '@storyblok/field-plugin'
+
+vi.mock('@storyblok/field-plugin/react')
+
+const fieldPluginDefault: FieldPluginResponse<number | undefined> = {
+  type: 'loaded',
+  data: {
+    isModalOpen: false,
+    content: undefined,
+    options: {},
+    spaceId: undefined,
+    storyLang: '',
+    story: {
+      content: {},
+    },
+    storyId: undefined,
+    blockUid: undefined,
+    token: undefined,
+    uid: '',
+  },
+  actions: {
+    setContent: vi.fn(),
+    setModalOpen: vi.fn(),
+    requestContext: vi.fn(),
+    selectAsset: vi.fn(),
+  },
+}
+
+describe('FieldPluginExammple', () => {
+  test('should work', () => {
+    vi.mocked(useFieldPlugin).mockReturnValue(fieldPluginDefault)
+    render(<FieldPlugin />)
+    const headline = screen.getByText('Field Value')
+    expect(headline).toBeInTheDocument()
+  })
+})

--- a/packages/cli/templates/react/src/setupTests.ts
+++ b/packages/cli/templates/react/src/setupTests.ts
@@ -1,0 +1,8 @@
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// runs a cleanup after each test case (e.g. clearing jsdom)
+afterEach(() => {
+  cleanup()
+})

--- a/packages/cli/templates/react/tsconfig.node.json
+++ b/packages/cli/templates/react/tsconfig.node.json
@@ -6,6 +6,7 @@
     "allowSyntheticDefaultImports": true
   },
   "include": [
-    "vite.config.ts"
+    "vite.config.ts",
+    "vitest.config.ts"
   ]
 }

--- a/packages/cli/templates/react/vitest.config.ts
+++ b/packages/cli/templates/react/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./src/setupTests.ts'],
+    },
+  }),
+)


### PR DESCRIPTION
## What?

Setup `vitest` for the react example field-type plugin

## Why?

As a developer, I love to write tests so that nobody can mess with my code, and my pipeline will tell me if so.

## How to test? (optional)

run `npx @storyblok/field-plugin-cli@beta` and select `react` template. After completion, run `yarn test` in your plugin directory.

