### PR TITLE
docs(template): add documentation on manifest file

### DIFF
--- a/packages/cli/templates/js/README.md
+++ b/packages/cli/templates/js/README.md
@@ -48,8 +48,6 @@ The options list within the file `field-plugin.config.json` should consist of ke
 Now, you just need to access these options in your code like in the example below:
 
 ```js
-const { type, data, actions } = useFieldPlugin()
-
 console.log(data.options.myPluginInitialValue)
 ```
 

--- a/packages/cli/templates/js/README.md
+++ b/packages/cli/templates/js/README.md
@@ -30,22 +30,9 @@ The manifest file is a configuration that enhances the functionality of your fie
 
 The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
-### Creating a Manifest File
+### Configuring a Manifest File
 
-If your field plugin doesn't already contain a manifest file, you can create one yourself at any time by following these steps:
-
-1. Begin by creating a `field-plugin.config.json` file in the root folder of your project.
-2. Populate the file with the following content:
-
-```json
-{
-  "options": []
-}
-```
-
-That's all there is to it.
-
-The options list within this file should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
+The options list within the file `field-plugin.config.json` should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
 
 ```json
 {

--- a/packages/cli/templates/js/README.md
+++ b/packages/cli/templates/js/README.md
@@ -26,13 +26,9 @@ npm run deploy
 
 ## Manifest File for Field Plugins
 
-The manifest file is a valuable component that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
+The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-When this file is present, it empowers our CLI and build tools to efficiently access its contents, resulting in smoother deployment experiences.
-
-Moreover, during the development phase, this manifest file plays a crucial role in the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/). All the `options` defined within this file are automatically integrated, simplifying your workflow.
-
-While most field plugins created using our templates include this manifest file, you may find that your custom plugin lacks it. In such cases, follow the steps below to easily set it up.
+The manifest file allows you to configure options for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Creating a Manifest File
 
@@ -62,7 +58,13 @@ The options list within this file should consist of key-value objects representi
 }
 ```
 
-By creating and maintaining this manifest file, you ensure that the CLI can effortlessly read and synchronize these options during each deployment. This streamlines the entire process, making your field plugin development more efficient and hassle-free.
+Now, you just need to access these options in your code like in the example below:
+
+```js
+const { type, data, actions } = useFieldPlugin()
+
+console.log(data.options.myPluginInitialValue)
+```
 
 ## Next Steps
 

--- a/packages/cli/templates/js/README.md
+++ b/packages/cli/templates/js/README.md
@@ -28,7 +28,7 @@ npm run deploy
 
 The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-The manifest file allows you to configure options for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
+The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Creating a Manifest File
 

--- a/packages/cli/templates/js/README.md
+++ b/packages/cli/templates/js/README.md
@@ -24,6 +24,46 @@ Deploy the field plugin with the CLI. Issue a [personal access token](https://ap
 npm run deploy
 ```
 
+## Manifest File for Field Plugins
+
+The manifest file is a valuable component that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
+
+When this file is present, it empowers our CLI and build tools to efficiently access its contents, resulting in smoother deployment experiences.
+
+Moreover, during the development phase, this manifest file plays a crucial role in the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/). All the `options` defined within this file are automatically integrated, simplifying your workflow.
+
+While most field plugins created using our templates include this manifest file, you may find that your custom plugin lacks it. In such cases, follow the steps below to easily set it up.
+
+### Creating a Manifest File
+
+If your field plugin doesn't already contain a manifest file, you can create one yourself at any time by following these steps:
+
+1. Begin by creating a `field-plugin.config.json` file in the root folder of your project.
+2. Populate the file with the following content:
+
+```json
+{
+  "options": []
+}
+```
+
+That's all there is to it.
+
+The options list within this file should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
+
+```json
+{
+  "options": [
+    {
+      "name": "myPluginInitialValue",
+      "value": 100
+    }
+  ]
+}
+```
+
+By creating and maintaining this manifest file, you ensure that the CLI can effortlessly read and synchronize these options during each deployment. This streamlines the entire process, making your field plugin development more efficient and hassle-free.
+
 ## Next Steps
 
 Read more about field plugins [on GitHub](https://github.com/storyblok/field-plugin).

--- a/packages/cli/templates/react/README.md
+++ b/packages/cli/templates/react/README.md
@@ -34,22 +34,9 @@ The manifest file is a configuration that enhances the functionality of your fie
 
 The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
-### Creating a Manifest File
+### Configuring a Manifest File
 
-If your field plugin doesn't already contain a manifest file, you can create one yourself at any time by following these steps:
-
-1. Begin by creating a `field-plugin.config.json` file in the root folder of your project.
-2. Populate the file with the following content:
-
-```json
-{
-  "options": []
-}
-```
-
-That's all there is to it.
-
-The options list within this file should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
+The options list within the file `field-plugin.config.json` should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
 
 ```json
 {

--- a/packages/cli/templates/react/README.md
+++ b/packages/cli/templates/react/README.md
@@ -28,6 +28,46 @@ Deploy the field plugin with the CLI. Issue a [personal access token](https://ap
 npm run deploy
 ```
 
+## Manifest File for Field Plugins
+
+The manifest file is a valuable component that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
+
+When this file is present, it empowers our CLI and build tools to efficiently access its contents, resulting in smoother deployment experiences.
+
+Moreover, during the development phase, this manifest file plays a crucial role in the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/). All the `options` defined within this file are automatically integrated, simplifying your workflow.
+
+While most field plugins created using our templates include this manifest file, you may find that your custom plugin lacks it. In such cases, follow the steps below to easily set it up.
+
+### Creating a Manifest File
+
+If your field plugin doesn't already contain a manifest file, you can create one yourself at any time by following these steps:
+
+1. Begin by creating a `field-plugin.config.json` file in the root folder of your project.
+2. Populate the file with the following content:
+
+```json
+{
+  "options": []
+}
+```
+
+That's all there is to it.
+
+The options list within this file should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
+
+```json
+{
+  "options": [
+    {
+      "name": "myPluginInitialValue",
+      "value": 100
+    }
+  ]
+}
+```
+
+By creating and maintaining this manifest file, you ensure that the CLI can effortlessly read and synchronize these options during each deployment. This streamlines the entire process, making your field plugin development more efficient and hassle-free.
+
 ## Next Steps
 
 Read more about field plugins [on GitHub](https://github.com/storyblok/field-plugin).

--- a/packages/cli/templates/react/README.md
+++ b/packages/cli/templates/react/README.md
@@ -30,13 +30,9 @@ npm run deploy
 
 ## Manifest File for Field Plugins
 
-The manifest file is a valuable component that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
+The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-When this file is present, it empowers our CLI and build tools to efficiently access its contents, resulting in smoother deployment experiences.
-
-Moreover, during the development phase, this manifest file plays a crucial role in the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/). All the `options` defined within this file are automatically integrated, simplifying your workflow.
-
-While most field plugins created using our templates include this manifest file, you may find that your custom plugin lacks it. In such cases, follow the steps below to easily set it up.
+The manifest file allows you to configure options for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Creating a Manifest File
 
@@ -66,7 +62,13 @@ The options list within this file should consist of key-value objects representi
 }
 ```
 
-By creating and maintaining this manifest file, you ensure that the CLI can effortlessly read and synchronize these options during each deployment. This streamlines the entire process, making your field plugin development more efficient and hassle-free.
+Now, you just need to access these options in your code like in the example below:
+
+```js
+const { type, data, actions } = useFieldPlugin()
+
+console.log(data.options.myPluginInitialValue)
+```
 
 ## Next Steps
 

--- a/packages/cli/templates/react/README.md
+++ b/packages/cli/templates/react/README.md
@@ -32,7 +32,7 @@ npm run deploy
 
 The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-The manifest file allows you to configure options for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
+The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Creating a Manifest File
 

--- a/packages/cli/templates/vue2/README.md
+++ b/packages/cli/templates/vue2/README.md
@@ -30,22 +30,9 @@ The manifest file is a configuration that enhances the functionality of your fie
 
 The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
-### Creating a Manifest File
+### Configuring a Manifest File
 
-If your field plugin doesn't already contain a manifest file, you can create one yourself at any time by following these steps:
-
-1. Begin by creating a `field-plugin.config.json` file in the root folder of your project.
-2. Populate the file with the following content:
-
-```json
-{
-  "options": []
-}
-```
-
-That's all there is to it.
-
-The options list within this file should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
+The options list within the file `field-plugin.config.json` should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
 
 ```json
 {

--- a/packages/cli/templates/vue2/README.md
+++ b/packages/cli/templates/vue2/README.md
@@ -26,13 +26,9 @@ npm run deploy
 
 ## Manifest File for Field Plugins
 
-The manifest file is a valuable component that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
+The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-When this file is present, it empowers our CLI and build tools to efficiently access its contents, resulting in smoother deployment experiences.
-
-Moreover, during the development phase, this manifest file plays a crucial role in the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/). All the `options` defined within this file are automatically integrated, simplifying your workflow.
-
-While most field plugins created using our templates include this manifest file, you may find that your custom plugin lacks it. In such cases, follow the steps below to easily set it up.
+The manifest file allows you to configure options for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Creating a Manifest File
 
@@ -62,7 +58,13 @@ The options list within this file should consist of key-value objects representi
 }
 ```
 
-By creating and maintaining this manifest file, you ensure that the CLI can effortlessly read and synchronize these options during each deployment. This streamlines the entire process, making your field plugin development more efficient and hassle-free.
+Now, you just need to access these options in your code like in the example below:
+
+```js
+const { type, data, actions } = useFieldPlugin()
+
+console.log(data.options.myPluginInitialValue)
+```
 
 ## Next Steps
 

--- a/packages/cli/templates/vue2/README.md
+++ b/packages/cli/templates/vue2/README.md
@@ -48,9 +48,19 @@ The options list within the file `field-plugin.config.json` should consist of ke
 Now, you just need to access these options in your code like in the example below:
 
 ```js
-const { type, data, actions } = useFieldPlugin()
+<script>
+export default {
+  ...
+  mixins: [fieldPluginMixin],
+  ...
+}
+</script>
 
-console.log(data.options.myPluginInitialValue)
+<template>
+  <div v-if="plugin.type === 'loaded'">
+    <pre>{{ plugin.data.options.myPluginInitialValue }}</pre>
+  </div>
+</template>
 ```
 
 ## Next Steps

--- a/packages/cli/templates/vue2/README.md
+++ b/packages/cli/templates/vue2/README.md
@@ -28,7 +28,7 @@ npm run deploy
 
 The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-The manifest file allows you to configure options for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
+The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Creating a Manifest File
 

--- a/packages/cli/templates/vue2/README.md
+++ b/packages/cli/templates/vue2/README.md
@@ -24,6 +24,46 @@ Deploy the field plugin with the CLI. Issue a [personal access token](https://ap
 npm run deploy
 ```
 
+## Manifest File for Field Plugins
+
+The manifest file is a valuable component that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
+
+When this file is present, it empowers our CLI and build tools to efficiently access its contents, resulting in smoother deployment experiences.
+
+Moreover, during the development phase, this manifest file plays a crucial role in the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/). All the `options` defined within this file are automatically integrated, simplifying your workflow.
+
+While most field plugins created using our templates include this manifest file, you may find that your custom plugin lacks it. In such cases, follow the steps below to easily set it up.
+
+### Creating a Manifest File
+
+If your field plugin doesn't already contain a manifest file, you can create one yourself at any time by following these steps:
+
+1. Begin by creating a `field-plugin.config.json` file in the root folder of your project.
+2. Populate the file with the following content:
+
+```json
+{
+  "options": []
+}
+```
+
+That's all there is to it.
+
+The options list within this file should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
+
+```json
+{
+  "options": [
+    {
+      "name": "myPluginInitialValue",
+      "value": 100
+    }
+  ]
+}
+```
+
+By creating and maintaining this manifest file, you ensure that the CLI can effortlessly read and synchronize these options during each deployment. This streamlines the entire process, making your field plugin development more efficient and hassle-free.
+
 ## Next Steps
 
 Read more about field plugins [on GitHub](https://github.com/storyblok/field-plugin).

--- a/packages/cli/templates/vue3/README.md
+++ b/packages/cli/templates/vue3/README.md
@@ -34,7 +34,7 @@ npm run deploy
 
 The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-The manifest file allows you to configure options for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
+The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Creating a Manifest File
 

--- a/packages/cli/templates/vue3/README.md
+++ b/packages/cli/templates/vue3/README.md
@@ -36,22 +36,9 @@ The manifest file is a configuration that enhances the functionality of your fie
 
 The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
-### Creating a Manifest File
+### Configuring a Manifest File
 
-If your field plugin doesn't already contain a manifest file, you can create one yourself at any time by following these steps:
-
-1. Begin by creating a `field-plugin.config.json` file in the root folder of your project.
-2. Populate the file with the following content:
-
-```json
-{
-  "options": []
-}
-```
-
-That's all there is to it.
-
-The options list within this file should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
+The options list within the file `field-plugin.config.json` should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
 
 ```json
 {

--- a/packages/cli/templates/vue3/README.md
+++ b/packages/cli/templates/vue3/README.md
@@ -32,13 +32,9 @@ npm run deploy
 
 ## Manifest File for Field Plugins
 
-The manifest file is a valuable component that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
+The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-When this file is present, it empowers our CLI and build tools to efficiently access its contents, resulting in smoother deployment experiences.
-
-Moreover, during the development phase, this manifest file plays a crucial role in the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/). All the `options` defined within this file are automatically integrated, simplifying your workflow.
-
-While most field plugins created using our templates include this manifest file, you may find that your custom plugin lacks it. In such cases, follow the steps below to easily set it up.
+The manifest file allows you to configure options for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Creating a Manifest File
 
@@ -68,7 +64,13 @@ The options list within this file should consist of key-value objects representi
 }
 ```
 
-By creating and maintaining this manifest file, you ensure that the CLI can effortlessly read and synchronize these options during each deployment. This streamlines the entire process, making your field plugin development more efficient and hassle-free.
+Now, you just need to access these options in your code like in the example below:
+
+```js
+const { type, data, actions } = useFieldPlugin()
+
+console.log(data.options.myPluginInitialValue)
+```
 
 ## Next Steps
 

--- a/packages/cli/templates/vue3/README.md
+++ b/packages/cli/templates/vue3/README.md
@@ -30,6 +30,46 @@ Deploy the field plugin with the CLI. Issue a [personal access token](https://ap
 npm run deploy
 ```
 
+## Manifest File for Field Plugins
+
+The manifest file is a valuable component that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
+
+When this file is present, it empowers our CLI and build tools to efficiently access its contents, resulting in smoother deployment experiences.
+
+Moreover, during the development phase, this manifest file plays a crucial role in the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/). All the `options` defined within this file are automatically integrated, simplifying your workflow.
+
+While most field plugins created using our templates include this manifest file, you may find that your custom plugin lacks it. In such cases, follow the steps below to easily set it up.
+
+### Creating a Manifest File
+
+If your field plugin doesn't already contain a manifest file, you can create one yourself at any time by following these steps:
+
+1. Begin by creating a `field-plugin.config.json` file in the root folder of your project.
+2. Populate the file with the following content:
+
+```json
+{
+  "options": []
+}
+```
+
+That's all there is to it.
+
+The options list within this file should consist of key-value objects representing the essential options required for your field plugin to function correctly, along with their corresponding values. This is an example of how it should be structured:
+
+```json
+{
+  "options": [
+    {
+      "name": "myPluginInitialValue",
+      "value": 100
+    }
+  ]
+}
+```
+
+By creating and maintaining this manifest file, you ensure that the CLI can effortlessly read and synchronize these options during each deployment. This streamlines the entire process, making your field plugin development more efficient and hassle-free.
+
 ## Next Steps
 
 Read more about field plugins [on GitHub](https://github.com/storyblok/field-plugin).


### PR DESCRIPTION
## What?
Add details about the manifest file setup inside our templates.

## Why?

JIRA: EXT-1881