### PR TITLE
fix(template): Update the CLI version used by the templates

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -11,7 +11,7 @@ In case no command is present the CLI will default to the `create` command.
 [//]: # 'TBD: add yarn create as soon as it is implemented'
 
 ```bash
-npx @storyblok/field-plugin-cli@beta [command] [options]
+npx @storyblok/field-plugin-cli@rc [command] [options]
 ```
 
 Available options and commands:
@@ -170,15 +170,15 @@ npx @storyblok/field-plugin-cli deploy --token=<TOKEN> --dir=<PATH_TO_DIR>
 You can add the CLI to an existing field plugin project by running:
 
 ```bash
-yarn add --dev @storyblok/field-plugin-cli@beta
+yarn add --dev @storyblok/field-plugin-cli@rc
 ```
 
 In case you want to access the dependency globally use:
 
 ```bash
-yarn global add @storyblok/field-plugin-cli@beta
+yarn global add @storyblok/field-plugin-cli@rc
 # or
-npm install @storyblok/field-plugin-cli@beta --global
+npm install @storyblok/field-plugin-cli@rc --global
 ```
 
 [//]: # 'TBD Add GIF with interactive mode'
@@ -208,7 +208,7 @@ Please see our [contributing guidelines](https://github.com/storyblok/.github/bl
 When adding a new template to this repository, think of the following:
 
 - `.gitignore` files must be named `gitignore`. Otherwise, NPM will exclude the file from the release. The `@storyblok/field-plugin-cli` will automatically rename the file to `.gitignore`.
-- Add `"deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"` to the `package.json`
+- Add `"deploy": "npm run build && npx @storyblok/field-plugin-cli@rc deploy"` to the `package.json`
 
 ## :1st_place_medal: Credits
 

--- a/packages/cli/src/commands/__tests__/add.test.ts
+++ b/packages/cli/src/commands/__tests__/add.test.ts
@@ -33,9 +33,7 @@ describe('add', () => {
     const packageJson = JSON.parse(
       (await readFile(`${dir}/${name}/package.json`)).toString(),
     ) as PackageJson
-    expect(packageJson['scripts']['deploy']).toMatchInlineSnapshot(
-      '"npm run build && npx @storyblok/field-plugin-cli@beta deploy"',
-    )
+    expect(packageJson['scripts']['deploy']).toMatchInlineSnapshot('"npm run build && npx @storyblok/field-plugin-cli@rc deploy"')
     expect(files).toMatchInlineSnapshot(`
       [
         ".env.local.example",
@@ -73,9 +71,7 @@ describe('add', () => {
     const packageJson = JSON.parse(
       (await readFile(`${dir}/${name}/package.json`)).toString(),
     ) as PackageJson
-    expect(packageJson['scripts']['deploy']).toMatchInlineSnapshot(
-      '"npm run build && npx @storyblok/field-plugin-cli@beta deploy --dotEnvPath \'../../.env\'"',
-    )
+    expect(packageJson['scripts']['deploy']).toMatchInlineSnapshot('"npm run build && npx @storyblok/field-plugin-cli@rc deploy --dotEnvPath \'../../.env\'"')
     expect(files).toMatchInlineSnapshot(`
       [
         ".eslintrc.cjs",

--- a/packages/cli/templates/js/package.json
+++ b/packages/cli/templates/js/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "check:types": "tsc --noEmit",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@rc deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "1.0.0-rc.2"

--- a/packages/cli/templates/react/package.json
+++ b/packages/cli/templates/react/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@rc deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "1.0.0-rc.2",

--- a/packages/cli/templates/vue2/package.json
+++ b/packages/cli/templates/vue2/package.json
@@ -9,7 +9,7 @@
     "build:post": "rollup --config rollup.postbuild.config.js",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@rc deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "1.0.0-rc.2",

--- a/packages/cli/templates/vue3/package.json
+++ b/packages/cli/templates/vue3/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && npx @storyblok/field-plugin-cli@beta deploy"
+    "deploy": "npm run build && npx @storyblok/field-plugin-cli@rc deploy"
   },
   "dependencies": {
     "@storyblok/field-plugin": "1.0.0-rc.2",


### PR DESCRIPTION
## What?
Update the CLI version from beta to rc in all field plugin templates.

## Why?

JIRA: EXT-2042

This will allow the manifest deployment to work for new plugins when calling the deploy script located in the respective package.json files.