### PR TITLE
chore(common): setup all-contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,4 @@
+{
+  "projectName": "field-plugin",
+  "projectOwner": "storyblok"
+}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ npx @storyblok/field-plugin-cli@beta create
 ```
 
 For more details, please refer to the [documentation](https://www.storyblok.com/docs/plugins/field-plugins/introduction).
+
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
## What?

This PR sets up [all-contributors](https://allcontributors.org) to recognize all the contributors to this repository.

Once this is set up, you can use it like [this](https://allcontributors.org/docs/en/bot/usage).

(Types of contributions supported: https://allcontributors.org/docs/en/emoji-key#table)

