### PR TITLE
Fix the types

### DIFF
--- a/packages/field-plugin/package.json
+++ b/packages/field-plugin/package.json
@@ -6,30 +6,18 @@
   "files": [
     "dist"
   ],
-  "type": "module",
-  "module": "./dist/field-plugin.js",
-  "main": "./dist/field-plugin.umd.cjs",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/field-plugin.js",
+  "module": "./dist/field-plugin.mjs",
   "exports": {
     ".": {
-      "import": "./dist/field-plugin.js",
-      "require": "./dist/field-plugin.umd.cjs",
-      "types": "./dist/index.d.ts"
-    },
-    "./react": {
-      "import": "./dist/react/index.js",
-      "require": "./dist/react/index.umd.cjs",
-      "types": "./dist/react/index.d.ts"
-    },
-    "./vue3": {
-      "import": "./dist/vue3/index.js",
-      "require": "./dist/vue3/index.umd.cjs",
-      "types": "./dist/vue3/index.d.ts"
-    },
-    "./vite": {
-      "import": "./dist/vite/index.js",
-      "require": "./dist/vite/index.umd.cjs",
-      "types": "./dist/vite/index.d.ts"
+      "require": {
+        "types": "./dist/field-plugin.d.ts",
+        "default": "./dist/field-plugin.js"
+      },
+      "import": {
+        "types": "./dist/field-plugin.d.ts",
+        "default": "./dist/field-plugin.mjs"
+      }
     }
   },
   "repository": {

--- a/packages/field-plugin/vite.config.ts
+++ b/packages/field-plugin/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       entry: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
       name: 'FieldPlugin',
       fileName: 'field-plugin',
+      formats: ['es', 'cjs'],
     },
     emptyOutDir: false,
   },


### PR DESCRIPTION
Issue: EXT-1978

This is the best result so far I've achieved...

I isolated our helper and tried to first fix our library, and the best result I got was

**now**
![image](https://github.com/storyblok/field-plugin/assets/1240591/daa381df-64c1-4eed-a386-59a398f67aa8)

**before**
![image](https://github.com/storyblok/field-plugin/assets/1240591/f8fe0848-9cd3-4639-9e82-629f1e8320ce)

I had also tried [publint](https://publint.dev/) and the result was:

**now**
![image](https://github.com/storyblok/field-plugin/assets/1240591/f7dc1a30-44c0-4cc7-8593-ad18925c16e6)

**before**
![image](https://github.com/storyblok/field-plugin/assets/1240591/bfa9ea04-23af-4598-bda5-698fce61385f)

PS: It's only considering the field-plugin library, no helper was considered in these tests.

I had tried with `tsup` and also changes in our `vite.config.ts` file and I got everything "green" for both cases (only library), however, it was not working for the helpers... the helpers weren't able to resolve the field-plugin's type anymore.

Anyway, [here](https://github.com/storyblok/field-plugin/pull/309) is the example changing only our `vite.config.ts` file. 

Below you can see the result:
![image](https://github.com/storyblok/field-plugin/assets/1240591/5e277ab1-69b7-47a1-9055-9d06c1a2384b)

## How to test? (optional)

```
cd packages/field-plugin

yarn build && npx attw --pack .

# also with publint
yarn build && npx publint
```