### PR TITLE
chore(template): fix indentation of manifest files

### DIFF
--- a/packages/cli/templates/js/field-plugin.config.json
+++ b/packages/cli/templates/js/field-plugin.config.json
@@ -1,3 +1,3 @@
 {
-    "options": []
+  "options": []
 }

--- a/packages/cli/templates/react/field-plugin.config.json
+++ b/packages/cli/templates/react/field-plugin.config.json
@@ -1,3 +1,3 @@
 {
-    "options": []
+  "options": []
 }

--- a/packages/cli/templates/vue2/field-plugin.config.json
+++ b/packages/cli/templates/vue2/field-plugin.config.json
@@ -1,3 +1,3 @@
 {
-    "options": []
+  "options": []
 }

--- a/packages/cli/templates/vue3/field-plugin.config.json
+++ b/packages/cli/templates/vue3/field-plugin.config.json
@@ -1,3 +1,3 @@
 {
-    "options": []
+  "options": []
 }


### PR DESCRIPTION
## What?

This PR fixes the indentation of manifest files (from 4 spaces to 2 spaces, according to the overall configuration in this repository)