### PR TITLE
feat(cli): publish field types on deploys

### DIFF
--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -342,17 +342,17 @@ export const createFieldType: CreateFieldTypeFunc = async ({
 }) => {
   const newFieldPlugin = await client.createFieldType({ name, body })
 
-  //since the API doesn't accept options during creation time,
-  //we need to force an update in case options were found in
-  //the manifest file.
-  if (options !== undefined && options.length > 0) {
-    await client.updateFieldType({
-      id: newFieldPlugin.id,
-      field_type: {
-        options,
-      },
-    })
-  }
+  //since `options` and `publish` properties are only accepted during updates,
+  //we need to force an update call right after the creation.
+  //If no options is found, it's not going to be sent to the API since undefined
+  //properties are not encoded.
+  await client.updateFieldType({
+    id: newFieldPlugin.id,
+    publish: true,
+    field_type: {
+      options,
+    },
+  })
 
   return newFieldPlugin
 }

--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -102,6 +102,7 @@ export const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {
 
       await storyblokClient.updateFieldType({
         id: fieldPlugin.id,
+        publish: true,
         field_type: {
           body: output,
           options: manifest?.options,

--- a/packages/cli/src/storyblok/storyblok-client.ts
+++ b/packages/cli/src/storyblok/storyblok-client.ts
@@ -21,6 +21,7 @@ type CreateFieldTypeFunc = (body: {
 type UpdateFieldTypeFunc = (args: {
   id: number
   field_type: Partial<FieldType>
+  publish: boolean
 }) => Promise<void>
 
 type FetchFieldTypesFunc = (page?: number) => Promise<FieldType[]>
@@ -88,13 +89,18 @@ export const StoryblokClient: StoryblokClientFunc = ({ token, scope }) => {
     return results
   }
 
-  const updateFieldType: UpdateFieldTypeFunc = async ({ id, field_type }) => {
+  const updateFieldType: UpdateFieldTypeFunc = async ({
+    id,
+    field_type,
+    publish,
+  }) => {
     const fetch = (await import('node-fetch')).default
     const response = await fetch(`${FIELD_TYPES_API_ENDPOINT}${id}`, {
       method: 'PUT',
       headers: headers,
       body: JSON.stringify({
         field_type,
+        publish,
       }),
     })
     // The Update API returns an empty string as response body


### PR DESCRIPTION
## What?
This PR enhances our CLI deployment process to always publish the field type whenever a new or existing field type is deployed.

## Why?

JIRA: EXT-2074

Currently, all the field types deployed using our CLI are being saved but not published. 
As we don't see a use case for this scenario, we're changing this behavior to always publish field-types for new deploys or updates.


