### PR TITLE
fix(cli): set specific version of pnpm for monorepos

### DIFF
--- a/packages/cli/src/commands/create/__tests__/monorepo.test.ts
+++ b/packages/cli/src/commands/create/__tests__/monorepo.test.ts
@@ -4,20 +4,23 @@ import { add } from '../../add'
 import { createMonorepo } from '../monorepo'
 import { randomString } from '../../../utils'
 import { vi } from 'vitest'
+import { CreateMonorepoArgs } from '../types'
 
 vi.mock('../../add')
 
-const createMonorepoSilently = async () => {
+const createMonorepoSilently = async (
+  options?: Partial<Pick<CreateMonorepoArgs, 'packageManager' | 'template'>>,
+) => {
   const repoName = randomString()
   const pluginName = randomString()
   const dir = tempDir
 
   await createMonorepo({
     dir,
-    packageManager: 'npm',
+    packageManager: options?.packageManager || 'npm',
     repoName,
     pluginName,
-    template: 'react',
+    template: options?.template || 'react',
   })
 
   return { repoName, pluginName, dir }
@@ -36,6 +39,36 @@ describe('monorepo', () => {
       dir: `${dir}/${repoName}/packages`,
       name: pluginName,
       packageManager: 'npm',
+      structure: 'monorepo',
+      template: 'react',
+    })
+
+    expect(await readdir(`${dir}/${repoName}`)).toMatchInlineSnapshot(`
+      [
+        ".env.local.example",
+        ".git",
+        ".gitignore",
+        ".nvmrc",
+        ".prettierrc",
+        "package.json",
+        "packages",
+        "tsconfig.base.json",
+        "tsconfig.node.base.json",
+        "vite-env.d.ts",
+      ]
+    `)
+  })
+
+  it('creates a monorepo structure with yarn', async () => {
+    const { repoName, pluginName, dir } = await createMonorepoSilently({
+      packageManager: 'yarn',
+    })
+
+    expect(add).toHaveBeenCalledTimes(1)
+    expect(add).toHaveBeenCalledWith({
+      dir: `${dir}/${repoName}/packages`,
+      name: pluginName,
+      packageManager: 'yarn',
       structure: 'monorepo',
       template: 'react',
     })

--- a/packages/cli/src/commands/create/monorepo.ts
+++ b/packages/cli/src/commands/create/monorepo.ts
@@ -7,7 +7,7 @@ import {
   writeFileSync,
 } from 'fs'
 import { bold, cyan } from 'kleur/colors'
-import { dirname, resolve } from 'path'
+import { dirname, resolve, basename } from 'path'
 import { MONOREPO_TEMPLATE_PATH } from '../../../config'
 import {
   betterPrompts,
@@ -101,7 +101,11 @@ export const createMonorepo: CreateMonorepoFunc = async ({
     }
 
     // skip yarn files if yarn is not the package manager
-    if (file.includes('.yarn') && packageManager !== 'yarn') {
+    const fileBasename = basename(file)
+    if (
+      (fileBasename === '.yarn' || fileBasename === '.yarnrc') &&
+      packageManager !== 'yarn'
+    ) {
       return
     }
 

--- a/packages/cli/src/commands/create/monorepo.ts
+++ b/packages/cli/src/commands/create/monorepo.ts
@@ -103,7 +103,7 @@ export const createMonorepo: CreateMonorepoFunc = async ({
     // skip yarn files if yarn is not the package manager
     const fileBasename = basename(file)
     if (
-      (fileBasename === '.yarn' || fileBasename === '.yarnrc') &&
+      (fileBasename === 'yarn-3.2.4.cjs' || fileBasename === '.yarnrc.yml') &&
       packageManager !== 'yarn'
     ) {
       return

--- a/packages/cli/src/commands/create/monorepo.ts
+++ b/packages/cli/src/commands/create/monorepo.ts
@@ -61,7 +61,8 @@ const specifyPackageManager = ({
     // eslint-disable-next-line functional/immutable-data
     json['scripts']['add-plugin'] += ` --packageManager ${packageManager}`
     // eslint-disable-next-line functional/immutable-data
-    json['packageManager'] = packageManager === 'yarn' ? 'yarn@3.2.4' : 'pnpm'
+    json['packageManager'] =
+      packageManager === 'yarn' ? 'yarn@3.2.4' : 'pnpm@8.14.0'
 
     writeFileSync(
       resolve(repoDir, 'package.json'),

--- a/packages/cli/src/commands/create/monorepo.ts
+++ b/packages/cli/src/commands/create/monorepo.ts
@@ -100,6 +100,11 @@ export const createMonorepo: CreateMonorepoFunc = async ({
       return
     }
 
+    // skip yarn files if yarn is not the package manager
+    if (file.includes('.yarn') && packageManager !== 'yarn') {
+      return
+    }
+
     const destFilePath = resolve(repoDir, file.slice(templatePath.length))
 
     mkdirSync(dirname(destFilePath), {


### PR DESCRIPTION
## What?
* Set specific version for pnpm in packageManager field in the package.json file when creating monorepos
* Exclude yarn specific files from monorepos that do not use yarn

## Why?
fixes #329 

* pnpm monorepo creation failed when pnpm is installed using Corepack. This issue was caused by the missing version of the packageManager in the package.json file
* Even if the monorepo was created with a package manager other than yarn the yarn specific config files were copied to the target folder.


## How to test? (optional)
I validated the corepack fix on my machine and tested monorepo creation with all package managers.
I expanded the test for monorepo creation to validate the yarn config file changes.