### PR TITLE
fix(lib): use origin for postMessage strictly

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -47,12 +47,11 @@ export const createFieldPlugin: CreateFieldPlugin = ({
     return () => undefined
   }
 
-  const { uid } = params
+  const { uid, secure, host } = params
+  const origin = `${secure ? 'https://' : 'http://'}${host}`
 
   const postToContainer = (message: unknown) => {
     try {
-      // TODO specify https://app.storyblok.com/ in production mode, * in dev mode
-      const origin = '*'
       window.parent.postMessage(message, origin)
     } catch (err) {
       if (isCloneable(message)) {
@@ -101,6 +100,7 @@ export const createFieldPlugin: CreateFieldPlugin = ({
 
   const cleanupMessageListenerSideEffects = createPluginMessageListener(
     params.uid,
+    origin,
     messageCallbacks,
   )
 

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -47,8 +47,11 @@ export const createFieldPlugin: CreateFieldPlugin = ({
     return () => undefined
   }
 
-  const { uid, secure, host } = params
-  const origin = `${secure ? 'https://' : 'http://'}${host}`
+  const { uid, host } = params
+  const origin =
+    host === 'plugin-sandbox.storyblok.com'
+      ? 'https://plugin-sandbox.storyblok.com'
+      : 'https://app.storyblok.com'
 
   const postToContainer = (message: unknown) => {
     try {

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/createPluginMessageListener.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/createPluginMessageListener.ts
@@ -17,6 +17,7 @@ export type PluginMessageCallbacks = {
 
 export type CreatePluginMessageListener = (
   uid: string,
+  origin: string,
   callbacks: PluginMessageCallbacks,
 ) => () => void
 
@@ -26,10 +27,13 @@ export type CreatePluginMessageListener = (
  */
 export const createPluginMessageListener: CreatePluginMessageListener = (
   uid,
+  origin,
   callbacks,
 ) => {
   const handleEvent = (event: MessageEvent<unknown>) => {
-    handlePluginMessage(event.data, uid, callbacks)
+    if (event.origin === origin) {
+      handlePluginMessage(event.data, uid, callbacks)
+    }
   }
   window.addEventListener('message', handleEvent, false)
 


### PR DESCRIPTION
## What?

This PR uses correct `origin` for postMessage.

## Why?

JIRA: EXT-2133

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)

Everything should work the same.