### PR TITLE
chore(common): add manifest-helper tests in CI/CD

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -15,7 +15,9 @@ jobs:
           cache: 'yarn'
       - run: yarn install
       - run: yarn eslint packages/cli
-      - run: yarn workspace @storyblok/field-plugin-cli test
+      - run: |
+          yarn workspace @storyblok/field-plugin-cli test
+          yarn workspace @storyblok/manifest-helper test
       - run: yarn workspace @storyblok/field-plugin-cli build
   standalone-vue2:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -23,6 +23,8 @@ jobs:
           yarn eslint packages/field-plugin
           yarn workspaces foreach --include "helper-*" run lint
       - name: Test
-        run: yarn workspace @storyblok/field-plugin test
+        run: |
+          yarn workspace @storyblok/field-plugin test
+          yarn workspace @storyblok/manifest-helper test
       - name: Build
         run: yarn workspace @storyblok/field-plugin build


### PR DESCRIPTION
## What?
Add manifest-helper tests in CI/CD

## Why?
Improve the quality and reliability of the project.


JIRA: EXT-2172