### PR TITLE
feat(cli): add a disclaimer on how the manifest options will behave when published

### DIFF
--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -268,7 +268,7 @@ export const lookForManifestOptions = (
   console.log(
     grey(
       bold(
-        `[info] Please note that the option values won't be shared with a real Field but they'll be available only inside the Field Plugin Editor`,
+        `[info] Please note that the option values will not be shared when this field plugin is added to a story. Only keys are configured for security reasons.`,
       ),
     ),
   )

--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -1,5 +1,14 @@
 import { readFileSync, lstatSync } from 'fs'
-import { bold, cyan, green, red, underline } from 'kleur/colors'
+import {
+  bold,
+  cyan,
+  gray,
+  green,
+  grey,
+  red,
+  underline,
+  yellow,
+} from 'kleur/colors'
 import { resolve } from 'path'
 import { type Choice } from 'prompts'
 import {
@@ -85,7 +94,10 @@ export const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {
 
   const storyblokClient = StoryblokClient({ token, scope })
 
+  lookForManifestOptions(manifest?.options)
+
   console.log(bold(cyan('[info] Checking existing field plugins...')))
+
   const allFieldPlugins = await storyblokClient.fetchAllFieldTypes()
   const fieldPlugin = allFieldPlugins.find(
     (fieldPlugin) => fieldPlugin.name === packageName,
@@ -228,14 +240,10 @@ export const confirmOptionsUpdate = async (
     return
   }
 
-  if (options.length > 0) {
-    console.log(green('> '), options.map((option) => option.name).join(', '))
-  }
-
   const message =
     options.length === 0
       ? 'The plugin options will be reset because your manifest file contains an empty array for options. Do you want to proceed?'
-      : `The options above found in your manifest file are going to replace the plugin options. Do you want to proceed?`
+      : `The options found in your manifest file are going to replace the plugin options. Do you want to proceed?`
 
   const { confirmed } = await betterPrompts<{
     confirmed: boolean
@@ -250,6 +258,29 @@ export const confirmOptionsUpdate = async (
     console.log(cyan(bold('[info]')), 'Aborting plugin update.')
     process.exit(1)
   }
+}
+
+export const lookForManifestOptions = (
+  options: ManifestOption[] | undefined,
+) => {
+  if (options?.length === 0) {
+    return
+  }
+
+  const concatenatedOptions =
+    options !== undefined
+      ? options?.map((option) => option.name).join(', ')
+      : ''
+
+  console.log(cyan(bold('[info] Options found:')), green(concatenatedOptions))
+
+  console.log(
+    grey(
+      bold(
+        `[info] Please note that the option values won't be shared with a real Field but they'll be available only inside the Field Plugin Editor`,
+      ),
+    ),
+  )
 }
 
 export const selectApiScope = async (

--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -1,5 +1,5 @@
 import { readFileSync, lstatSync } from 'fs'
-import { bold, cyan, green, grey, red } from 'kleur/colors'
+import { bold, cyan, green, grey, red, yellow } from 'kleur/colors'
 import { resolve } from 'path'
 import { type Choice } from 'prompts'
 import {
@@ -85,7 +85,7 @@ export const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {
 
   const storyblokClient = StoryblokClient({ token, scope })
 
-  lookForManifestOptions(manifest?.options)
+  printManifestOptions(manifest?.options)
 
   console.log(bold(cyan('[info] Checking existing field plugins...')))
 
@@ -251,9 +251,7 @@ export const confirmOptionsUpdate = async (
   }
 }
 
-export const lookForManifestOptions = (
-  options: ManifestOption[] | undefined,
-) => {
+export const printManifestOptions = (options: ManifestOption[] | undefined) => {
   if (options?.length === 0) {
     return
   }
@@ -266,9 +264,10 @@ export const lookForManifestOptions = (
   console.log(cyan(bold('[info] Options found:')), green(concatenatedOptions))
 
   console.log(
-    grey(
+    yellow(
       bold(
-        `[info] Please note that the option values will not be shared when this field plugin is added to a story. Only keys are configured for security reasons.`,
+        `[info] Please note that the option values will not be shared when this field plugin is added to a story. Only keys are configured for security reasons.\n` +
+          `[info] Learn more: https://www.storyblok.com/docs/plugins/field-plugins/storyblok-field-plugin#manifest-file-for-field-plugins`,
       ),
     ),
   )

--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -1,5 +1,5 @@
 import { readFileSync, lstatSync } from 'fs'
-import { bold, cyan, green, grey, red, yellow } from 'kleur/colors'
+import { bold, cyan, green, red, yellow } from 'kleur/colors'
 import { resolve } from 'path'
 import { type Choice } from 'prompts'
 import {

--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -1,14 +1,5 @@
 import { readFileSync, lstatSync } from 'fs'
-import {
-  bold,
-  cyan,
-  gray,
-  green,
-  grey,
-  red,
-  underline,
-  yellow,
-} from 'kleur/colors'
+import { bold, cyan, green, grey, red } from 'kleur/colors'
 import { resolve } from 'path'
 import { type Choice } from 'prompts'
 import {


### PR DESCRIPTION
## What?
Improve the printed messages regarding options found in a manifest file and add a disclaimer on what to expect about the behavior of these options when the plugin gets attached to a Field.

## Why?
It can be common for users to think that the option values (found in a manifest file) will be shared with a real Field when the plugin gets attached to it, but, it isn't the way it happens. 

To avoid sensitive data from getting leaked with other users, all the option values reside accessible only during development time (through the Field Plugin Editor or the Sandbox), and as soon as the field plugin gets attached to a real Field, only the option names are fetched and listed to the user to fulfill.

JIRA: EXT-2170

Creation with no options:
![manifest-creation-no-options](https://github.com/storyblok/field-plugin/assets/1240591/06daa0e0-a5df-4c80-84ce-58d3e49b53b9)

Creation with options:
![manifest-creation-with-options](https://github.com/storyblok/field-plugin/assets/1240591/dc104112-37db-4d0e-8171-3a05aad3c3b2)

Update with no options:
![manifest-update-no-options](https://github.com/storyblok/field-plugin/assets/1240591/dbe54e22-28c2-4f6c-b793-13d15a563e65)

Update with options:
![manifest-update-with-options](https://github.com/storyblok/field-plugin/assets/1240591/40eadc6e-b675-41bd-9b3d-3edcb15965dd)
