### PR TITLE
chore(common): fetch the latest version tag when bumping the version

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -106,6 +106,23 @@ const { version: currentVersion, name: packageName } = JSON.parse(
   readFileSync(`packages/${packageFolder}/package.json`).toString(),
 ) as { version: string; name: PackageName }
 
+const latestVersionTag = `${packageName}@${currentVersion}`
+print('')
+print(
+  bold(cyan(`🏷️  Fetch latest version tag:`)),
+  bold(green(`${latestVersionTag}`)),
+)
+print('')
+try {
+  await $`git fetch origin tag ${latestVersionTag} --no-tags`.quiet()
+} catch {
+  print(
+    bold(red('[Error]')),
+    `Error while fetching the latest version tag ${latestVersionTag}`,
+  )
+  exit(1)
+}
+
 print('')
 print(bold(cyan('💡 Commits since last release')))
 print('')

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -112,7 +112,6 @@ print(
   bold(cyan(`🏷️  Fetch latest version tag:`)),
   bold(green(`${latestVersionTag}`)),
 )
-print('')
 try {
   await $`git fetch origin tag ${latestVersionTag} --no-tags`.quiet()
 } catch {
@@ -125,7 +124,6 @@ try {
 
 print('')
 print(bold(cyan('💡 Commits since last release')))
-print('')
 const commits = (
   await $`git log ${packageName}@${currentVersion}..HEAD --oneline -- packages/${packageFolder}/`.quiet()
 ).toString()


### PR DESCRIPTION
## What?
It fetches the latest version tag before proceeding with the versioning bumping.

## Why?
If the developer doesn't have the latest tag locally, the script will fail to revise it. So, fetching it before will prevent it from happening.

![image](https://github.com/storyblok/field-plugin/assets/1240591/f800d8a8-e8df-46bb-a52a-252e09a6349c)

**Result**:
![image](https://github.com/storyblok/field-plugin/assets/1240591/af4b676c-3cbc-4760-b6f6-994825cc4b1e)

JIRA: EXT-2180

