### PR TITLE
fix(helper): test setup mimics sandbox environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,6 @@
     "dev:vue3": "yarn dev:template vue3",
     "test:template": "yarn workspace field-plugin-${0}-template test --config node_modules/.${0}-vite.config.ts --ui",
     "test:react": "yarn test:template react",
-    "test:js": "yarn test:template js",
-    "test:vue2": "yarn test:template vue2",
     "test:vue3": "yarn test:template vue3",
     "bump-version": "./scripts/bump-version.ts"
   },

--- a/packages/field-plugin/helpers/test/src/index.ts
+++ b/packages/field-plugin/helpers/test/src/index.ts
@@ -9,6 +9,8 @@ import {
 
 import { vi } from 'vitest'
 
+const sandboxOrigin: string = 'https://plugin-sandbox.storyblok.com'
+
 const getContainer = (sendToFieldPlugin: (data: unknown) => void) => {
   const schema = {
     field_type: 'test-field-plugin',
@@ -110,15 +112,20 @@ export const setupFieldPlugin = () => {
   let handleEvent: (event: MessageEvent<unknown>) => void
   const container = getContainer((data: unknown) => {
     // @ts-ignore
-    handleEvent({ data })
+    handleEvent({
+      data,
+      origin: sandboxOrigin,
+    })
   })
   global.ResizeObserver = class ResizeObserver {
     observe() {
       // do nothing
     }
+
     unobserve() {
       // do nothing
     }
+
     disconnect() {
       // do nothing
     }


### PR DESCRIPTION

## What?
This PR resolves CI breaking after PR #333 was merged. This error occurred because the origin inside the vitest environment was 'localhost' which is currently not permitted.

## Why?

[JIRA: EXT-2188](https://storyblok.atlassian.net/browse/EXT-2188)

## How to test? (optional)
1. Inside the root run `yarn test:react` and `yarn test:vue3`