### PR TITLE
chore(common): fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'yarn'
+  - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
## What?

This fixes the wrong dependabot configuration.

[The doc](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) says `yarn` is supported, but it actually [failed](https://github.com/storyblok/field-plugin/runs/21559520157).
