### PR TITLE
fix(common): assign reviewers for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+    reviwers:
+      - 'storyblok/plugins-team'
     # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-1
     groups:
       everything:


### PR DESCRIPTION
## What?

We've had dependabot configured, but it was wrong and didn't work. I [fixed it](https://github.com/storyblok/field-plugin/commit/f98ddbd11688698ba80a56d2c8efc0891f4a71d5) yesterday. In this PR, we're assigning the team as reviewer for dependabot PRs.

## Why?

JIRA: EXT-

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->