### PR TITLE
fix(lib): add translatable as part of the plugin payload

### DIFF
--- a/packages/field-plugin/helpers/test/src/index.ts
+++ b/packages/field-plugin/helpers/test/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  FieldPluginSchema,
   isAssetModalChangeMessage,
   isGetContextMessage,
   isHeightChangeMessage,
@@ -12,9 +13,10 @@ import { vi } from 'vitest'
 const sandboxOrigin: string = 'https://plugin-sandbox.storyblok.com'
 
 const getContainer = (sendToFieldPlugin: (data: unknown) => void) => {
-  const schema = {
+  const schema: FieldPluginSchema = {
     field_type: 'test-field-plugin',
     options: [],
+    translatable: false,
   }
   // @ts-ignore `height` is not used anywhere, but we keep it here.
   let height = undefined

--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
@@ -15,6 +15,7 @@ export type FieldPluginData<Content> = {
   blockUid: string | undefined
   token: string | undefined
   uid: string
+  translatable: boolean
   releases: Release[]
   releaseId: number | undefined
 }

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
@@ -65,7 +65,7 @@ describe('createPluginActions', () => {
         story: { content: {} },
         storyId: 123,
         token: null,
-        schema: { options: [], field_type: 'abc' },
+        schema: { options: [], field_type: 'abc', translatable: false },
         language: '',
         interfaceLanguage: 'en',
         model: randomString,

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/handlePluginMessage.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/handlePluginMessage.test.ts
@@ -60,7 +60,7 @@ describe('handlePluginMessage', () => {
       model: 123,
       spaceId: 1234,
       story: { content: {} },
-      schema: { options: [], field_type: 'avh' },
+      schema: { options: [], field_type: 'avh', translatable: false },
       storyId: 1344,
       token: 'rfwreff2435wewff43',
       isModalOpen: false,

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
@@ -29,6 +29,7 @@ export const pluginStateFromStateChangeMessage = <Content>(
     blockUid: message.blockId ?? undefined,
     token: message.token ?? undefined,
     options: recordFromFieldPluginOptions(message.schema.options),
+    translatable: message.schema.translatable ?? false,
     uid: message.uid ?? undefined,
     content: validateResult.content,
     isModalOpen: message.isModalOpen,

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/FieldPluginSchema.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/FieldPluginSchema.test.ts
@@ -127,6 +127,7 @@ describe('field plugin schema', () => {
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: [],
+          translatable: false,
         }),
       ).toEqual(true)
       expect(
@@ -140,6 +141,7 @@ describe('field plugin schema', () => {
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: [],
+          translatable: false,
         }),
       ).toEqual(true)
       expect(
@@ -184,6 +186,7 @@ describe('field plugin schema', () => {
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: [],
+          translatable: false,
         }),
       ).toEqual(true)
       expect(
@@ -197,6 +200,7 @@ describe('field plugin schema', () => {
         isFieldPluginSchema({
           field_type: 'field-type-name',
           options: [],
+          translatable: false,
         }),
       ).toEqual(true)
       expect(
@@ -245,6 +249,7 @@ describe('field plugin schema', () => {
         isFieldPluginSchema({
           field_type: 'name',
           options: [option],
+          translatable: false,
         }),
       ).toEqual(true)
       expect(

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/FieldPluginSchema.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/FieldPluginSchema.ts
@@ -6,6 +6,7 @@ import { hasKey } from '../../../utils'
 export type FieldPluginSchema = {
   field_type: string
   options: FieldPluginOption[]
+  translatable: boolean
 }
 
 export type FieldPluginOption = { name: string; value: string }
@@ -21,4 +22,6 @@ export const isFieldPluginSchema = (it: unknown): it is FieldPluginSchema =>
   typeof it.field_type === 'string' &&
   hasKey(it, 'options') &&
   Array.isArray(it.options) &&
-  it.options.every(isFieldPluginOption)
+  it.options.every(isFieldPluginOption) &&
+  hasKey(it, 'translatable') &&
+  typeof it.translatable === 'boolean'

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/LoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/LoadedMessage.test.ts
@@ -13,7 +13,7 @@ const stub: LoadedMessage = {
   story: { content: {} },
   language: '',
   interfaceLanguage: 'en',
-  schema: { options: [], field_type: 'blah' },
+  schema: { options: [], field_type: 'blah', translatable: false },
   releases: [],
   releaseId: undefined,
 }
@@ -122,6 +122,7 @@ describe('StateChangedMessage', () => {
                 value: 'ab',
               },
             ],
+            translatable: false,
           } as FieldPluginSchema,
         }),
       ).toEqual(true)


### PR DESCRIPTION
## What?

### Library
Added new property to the plugin.data object called `translatable`. This is a field setting that can be adjusted by the content editor and came in as a feature request from a customer. 

### Sandbox
In order to make the local development easier, sandbox was extended with a checkbox 'Translatable' where the user can manipulate the new property accordingly.

### Documentation
You can review the Documentation updated [here](https://app.storyblok.com/#/me/spaces/88751/stories/0/0/314827086).

### Open Tasks

- [x] Sandbox Changes
- [x] [Updating Documentation](https://www.storyblok.com/docs/plugins/field-plugins/storyblok-field-plugin)



## Why?

[JIRA: EXT-2225](https://storyblok.atlassian.net/browse/EXT-2225)
