### PR TITLE
feat(cli): check for duplicated names

### DIFF
--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -68,6 +68,7 @@ export const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {
         manifest?.options,
         dir,
         allFieldPlugins,
+        skipPrompts,
       )
 
       return { id: fieldPlugin.id }
@@ -106,6 +107,7 @@ export const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {
     manifest?.options,
     dir,
     allFieldPlugins,
+    skipPrompts,
   )
 
   return { id: fieldPlugin.id }
@@ -364,6 +366,7 @@ export const createFieldPlugin = async (
   options: ManifestOption[] | undefined,
   dir: string,
   allFieldPlugins: FieldType[],
+  skipPrompts: boolean,
 ): Promise<FieldType> => {
   const name =
     packageName !== '' ? packageName : await promptNewName(allFieldPlugins)
@@ -392,7 +395,7 @@ export const createFieldPlugin = async (
 
     return fieldPlugin
   } catch (err) {
-    if (getErrorMessage(err) !== 'DUPLICATED_NAME') {
+    if (skipPrompts || getErrorMessage(err) !== 'DUPLICATED_NAME') {
       // eslint-disable-next-line functional/no-throw-statement
       throw err
     }
@@ -411,6 +414,7 @@ export const createFieldPlugin = async (
       options,
       dir,
       allFieldPlugins,
+      skipPrompts,
     )
   }
 }

--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -52,8 +52,8 @@ export const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {
 
   console.log(bold(cyan('[info] Checking existing field plugins...')))
 
-  const allFieldPlugins = await storyblokClient.fetchAllFieldTypes()
-  const fieldPluginFound = allFieldPlugins.find(
+  const scopeFieldPlugins = await storyblokClient.fetchAllFieldTypes()
+  const fieldPluginFound = scopeFieldPlugins.find(
     (fieldPlugin) => fieldPlugin.name === packageName,
   )
 
@@ -67,7 +67,7 @@ export const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {
         output,
         manifest?.options,
         dir,
-        allFieldPlugins,
+        scopeFieldPlugins,
         skipPrompts,
       )
 
@@ -106,7 +106,7 @@ export const upsertFieldPlugin: UpsertFieldPluginFunc = async (args) => {
     output,
     manifest?.options,
     dir,
-    allFieldPlugins,
+    scopeFieldPlugins,
     skipPrompts,
   )
 
@@ -212,7 +212,7 @@ export const confirmNewName = async (currentName: string) => {
   return rename
 }
 
-export const promptNewName = async (allFieldPlugins: FieldType[]) => {
+export const promptNewName = async (scopeFieldPlugins: FieldType[]) => {
   const { name } = await betterPrompts<{ name: string }>({
     type: 'text',
     name: 'name',
@@ -222,7 +222,7 @@ export const promptNewName = async (allFieldPlugins: FieldType[]) => {
         return false
       }
 
-      return allFieldPlugins.every((plugin) => plugin.name !== name)
+      return scopeFieldPlugins.every((plugin) => plugin.name !== name)
     },
   })
   return name
@@ -365,11 +365,11 @@ export const createFieldPlugin = async (
   content: string,
   options: ManifestOption[] | undefined,
   dir: string,
-  allFieldPlugins: FieldType[],
-  skipPrompts: boolean,
+  scopeFieldPlugins: FieldType[],
+  skipPrompts?: boolean,
 ): Promise<FieldType> => {
   const name =
-    packageName !== '' ? packageName : await promptNewName(allFieldPlugins)
+    packageName !== '' ? packageName : await promptNewName(scopeFieldPlugins)
 
   try {
     const fieldPlugin = await client.createFieldType({
@@ -413,7 +413,7 @@ export const createFieldPlugin = async (
       content,
       options,
       dir,
-      allFieldPlugins,
+      scopeFieldPlugins,
       skipPrompts,
     )
   }


### PR DESCRIPTION
## What?
It allows our CLI to handle duplicated name errors when deploying new field plugins.

![image](https://github.com/storyblok/field-plugin/assets/1240591/28d6e3e0-4d08-40cd-a92c-5b5b65bed0ea)

## Why?

JIRA: EXT-2053

As we don't have an ENDPOINT to check globally (from all users and scopes) whether a plugin with the same name, already exists in someone's account or in a different scope, naming collisions can happen during creation time.

The idea then is to not check it before trying to create a new plugin (because we don't have an endpoint for doing it globally) but a failing first approach, meaning that if we are not sure if a plugin with the same name exists or not we first try to create it and if it fails due `name collision` error, we prompt the user to rename it and try again with the new name. The user is going to be prompted about providing a new name until a unique name is provided or he/she doesn't quit the deployment routine.

Changing the update flow wasn't necessary since the duplicated name error is raised only during creation time, but as I did some refactoring I think is worth to check also the update flow.

## How to test?
I think the easiest way to test it out maybe by, from the root of the repository, running:

```sh
yarn install

cd packages/cli/templates/react

yarn build && yarn build:cli && npx field-plugin deploy --token <your preview token>
```

The test scenarios I thought were:

1. Deploy a new field plugin with a set of options
    - If the new name is duplicated (meaning it belongs to another user or another scope), the user needs to be prompted to continue to rename it or to abort. Until the user doesn't choose a unique name he/she will be still prompted to choose a new name since the one chosen is not unique. The user can skip any time just by saying `no` when prompted the first time.
    - If a unique name is provided, then, the new field plugin and its options should be listed in the Field Plugin Editor.
2. Update the newly created field plugin with some other set of options
    - It should list all the new set of options in the Field Plugin Editor
3. Update the newly created field plugin with no options
    - It shouldn't list any option in the Field Plugin Editor since no option was found in the manifest file.
4. Try to update the newly created field plugin with a set of options but then, when prompted if the user wants to update the existing field plugin or to create a new one, proceed with the creation.
    - It should ask for a new name
    - If the user wants to save the new in the package.json, he/she can.
    - If the new name is duplicated (meaning it belongs to another user or another scope), the user needs to be prompted to continue to rename it or to abort. Until the user doesn't choose a unique name he/she will be still prompted to choose a new name since the one chosen is not unique. The user can skip any time just by saying `no` when prompted the first time.
    - If a unique name is provided, then, the new field plugin and its options should be listed in the Field Plugin Editor.
    
