### PR TITLE
chore(common): schedule dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       day: 'wednesday'
     ignore:
       - dependency-name: '*'


### PR DESCRIPTION
## What?

This PR reschedules dependabot to monthly, as we don't have enough bandwidth to check this PRs that often, and it's not that beneficial to us either.
