### PR TITLE
fix(lib): fix regression about postMessage target origin

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -51,7 +51,7 @@ export const createFieldPlugin: CreateFieldPlugin = ({
   const origin =
     host === 'plugin-sandbox.storyblok.com'
       ? 'https://plugin-sandbox.storyblok.com'
-      : 'https://app.storyblok.com'
+      : 'https://plugins.storyblok.com'
 
   const postToContainer = (message: unknown) => {
     try {

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/handlePluginMessage.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/handlePluginMessage.ts
@@ -17,7 +17,7 @@ export const handlePluginMessage = (
     return
   }
 
-  // TODO check origin https://app.storyblok.com/ in production mode, * in dev mode
+  // TODO check origin https://plugins.storyblok.com/ in production mode, * in dev mode
 
   if (data.uid !== uid) {
     // Not intended for this field plugin


### PR DESCRIPTION
## What?

This PR fixes the regression about postMessage target origin. We used to use `*`, but decided to be more explicit. However it's not `app.storyblok.com` but it was supposed to `plugins.storyblok.com`.
