### PR TITLE
chore(common): fix eslint warning

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,6 +58,13 @@ export default [
       ],
       'react/prop-types': 'off',
       'vue/multi-word-component-names': 'off',
+      'vue/html-self-closing': 'off',
+    },
+  },
+  {
+    files: ['!packages/cli/templates/vue2/**'],
+    rules: {
+      'vue/require-prop-types': 'off',
     },
   },
 ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,7 +62,7 @@ export default [
     },
   },
   {
-    files: ['!packages/cli/templates/vue2/**'],
+    files: ['packages/cli/templates/vue2/**'],
     rules: {
       'vue/require-prop-types': 'off',
     },

--- a/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
@@ -39,12 +39,12 @@ const plugin = useFieldPlugin({
         :count="plugin.data.content"
         @on-increase="plugin.actions.setContent(plugin.data.content + 1)"
       />
-      <hr>
+      <hr />
       <ModalToggle
         :is-modal-open="plugin.data.isModalOpen"
         :set-modal-open="plugin.actions.setModalOpen"
       />
-      <hr>
+      <hr />
       <AssetSelector :select-asset="plugin.actions.selectAsset" />
     </div>
   </div>

--- a/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
@@ -39,12 +39,12 @@ const plugin = useFieldPlugin({
         :count="plugin.data.content"
         @on-increase="plugin.actions.setContent(plugin.data.content + 1)"
       />
-      <hr />
+      <hr>
       <ModalToggle
         :is-modal-open="plugin.data.isModalOpen"
         :set-modal-open="plugin.actions.setModalOpen"
       />
-      <hr />
+      <hr>
       <AssetSelector :select-asset="plugin.actions.selectAsset" />
     </div>
   </div>


### PR DESCRIPTION
## What?

This PR fixes eslint warning by turning off some rules.

## Why?

prettier [automatically applies self closing tag](https://stackoverflow.com/questions/65105287/how-to-stop-prettier-from-using-the-old-self-closing-tag-syntax) `<hr> → <hr />`, and it happens normally by VSCode's prettier extension (I guess we all are using it).

However, we had an eslint rule that is the opposite. So they're conflicting. While it's impossible to configure prettier to stop doing that, we can disable this single eslint rule. Of course, we can setup git pre-commit hook, so that it can run `eslint --fixed`, so even if prettier applied the self closing tag, the eslint would fix it before commit. But I think that's a bit too much. If we really need to have that rule, then we could setup the git pre-commit hook.

