### PR TITLE
chore(common): fix scripts to run templates in dev

### DIFF
--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -18,21 +18,21 @@ export default defineConfig({
       process.env.NODE_ENV === 'production'
         ? []
         : [
-          {
-            find: /^@storyblok\/field-plugin$/,
-            replacement: path.resolve(
-              __dirname,
-              '../field-plugin/src/index.ts',
-            ),
-          },
-          {
-            find: /^@storyblok\/field-plugin\/react$/,
-            replacement: path.resolve(
-              __dirname,
-              '../field-plugin/helpers/react/src/index.ts',
-            ),
-          },
-        ],
+            {
+              find: /^@storyblok\/field-plugin$/,
+              replacement: path.resolve(
+                __dirname,
+                '../field-plugin/src/index.ts',
+              ),
+            },
+            {
+              find: /^@storyblok\/field-plugin\/react$/,
+              replacement: path.resolve(
+                __dirname,
+                '../lib-helpers/react/src/index.ts',
+              ),
+            },
+          ],
   },
   server: {
     port: 8080,

--- a/scripts/prepare-dev-vite-configs.mjs
+++ b/scripts/prepare-dev-vite-configs.mjs
@@ -46,13 +46,13 @@ for (const template of templates) {
       find: /^@storyblok\\/field-plugin\\/vue3$/,
       replacement: '${path.resolve(
         __dirname,
-        '../packages/field-plugin/helpers/vue3/src/index.ts',
+        '../packages/lib-helpers/vue3/src/index.ts',
       )}'
     }, {
       find: /^@storyblok\\/field-plugin\\/react$/,
       replacement: '${path.resolve(
         __dirname,
-        '../packages/field-plugin/helpers/react/src/index.ts',
+        '../packages/lib-helpers/react/src/index.ts',
       )}'
     }]
   },


### PR DESCRIPTION
## What?

#407 moved `packages/field-plugin/helpers` to `packages/lib-helpers` and it broke `yarn dev:vue3`, `yarn dev:xxx` commands. This PR fixes the regression.