### PR TITLE
feat(cli): on update process add flag to opt-out from publishing

### DIFF
--- a/packages/cli/src/__tests__/main.test.ts
+++ b/packages/cli/src/__tests__/main.test.ts
@@ -1,60 +1,20 @@
 import { createCLI } from '../main'
 import { create, add, deploy } from '../commands'
-import { vi } from 'vitest'
+import { describe, vi } from 'vitest'
 
 vi.mock('../commands')
 
 const DEFAULT_ARGS = ['node', 'main.ts'] // cli.parse() should receive the executable and its arget as its first two arguments.
 
 describe('main', () => {
-  describe('default arguments', () => {
-    it('create command', () => {
-      const cli = createCLI()
-      cli.parse([...DEFAULT_ARGS, 'create'])
-      expect(create).toHaveBeenCalledWith({ dir: '.' })
-    })
-
-    it('add command', () => {
+  describe('add command', () => {
+    it('default arguments', () => {
       const cli = createCLI()
       cli.parse([...DEFAULT_ARGS, 'add'])
       expect(add).toHaveBeenCalledWith({ dir: '.' })
     })
 
-    it('deploy command', () => {
-      const cli = createCLI()
-      cli.parse([...DEFAULT_ARGS, 'deploy'])
-      expect(deploy).toHaveBeenCalledWith({
-        dir: '.',
-        skipPrompts: false,
-        publish: true,
-      })
-    })
-  })
-
-  describe('full arguments', () => {
-    it('create command', () => {
-      const cli = createCLI()
-      cli.parse([
-        ...DEFAULT_ARGS,
-        'create',
-        '--dir',
-        'my-dir',
-        '--structure',
-        'monorepo',
-        '--pluginName',
-        'my-test-plugin',
-        '--repoName',
-        'my-test-repo',
-      ])
-      expect(create).toHaveBeenCalledWith({
-        dir: 'my-dir',
-        structure: 'monorepo',
-        pluginName: 'my-test-plugin',
-        repoName: 'my-test-repo',
-      })
-    })
-
-    it('add command', () => {
+    it('full arguments', () => {
       const cli = createCLI()
       cli.parse([
         ...DEFAULT_ARGS,
@@ -78,8 +38,60 @@ describe('main', () => {
         packageManager: 'npm',
       })
     })
+  })
 
-    it('deploy command', () => {
+  describe('create command', () => {
+    it('default arguments', () => {
+      const cli = createCLI()
+      cli.parse([...DEFAULT_ARGS, 'create'])
+      expect(create).toHaveBeenCalledWith({ dir: '.' })
+    })
+
+    it('full arguments', () => {
+      const cli = createCLI()
+      cli.parse([
+        ...DEFAULT_ARGS,
+        'create',
+        '--dir',
+        'my-dir',
+        '--structure',
+        'monorepo',
+        '--pluginName',
+        'my-test-plugin',
+        '--repoName',
+        'my-test-repo',
+      ])
+      expect(create).toHaveBeenCalledWith({
+        dir: 'my-dir',
+        structure: 'monorepo',
+        pluginName: 'my-test-plugin',
+        repoName: 'my-test-repo',
+      })
+    })
+  })
+
+  describe('deploy command', () => {
+    it('--no-publish', () => {
+      const cli = createCLI()
+      cli.parse([...DEFAULT_ARGS, 'deploy', '--no-publish'])
+      expect(deploy).toHaveBeenCalledWith({
+        dir: '.',
+        publish: false,
+        skipPrompts: false,
+      })
+    })
+
+    it('default options', () => {
+      const cli = createCLI()
+      cli.parse([...DEFAULT_ARGS, 'deploy'])
+      expect(deploy).toHaveBeenCalledWith({
+        dir: '.',
+        skipPrompts: false,
+        publish: true,
+      })
+    })
+
+    it('full arguments', () => {
       const cli = createCLI()
       cli.parse([
         ...DEFAULT_ARGS,

--- a/packages/cli/src/__tests__/main.test.ts
+++ b/packages/cli/src/__tests__/main.test.ts
@@ -23,7 +23,11 @@ describe('main', () => {
     it('deploy command', () => {
       const cli = createCLI()
       cli.parse([...DEFAULT_ARGS, 'deploy'])
-      expect(deploy).toHaveBeenCalledWith({ dir: '.', skipPrompts: false })
+      expect(deploy).toHaveBeenCalledWith({
+        dir: '.',
+        skipPrompts: false,
+        publish: true,
+      })
     })
   })
 
@@ -100,6 +104,7 @@ describe('main', () => {
         name: 'my-test-plugin',
         output: './dist/index.js',
         dir: 'my-directory',
+        publish: true,
         dotEnvPath: '.',
         scope: 'my-plugins',
       })

--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -381,6 +381,7 @@ export const createFieldPlugin = async (
     //we need to force an update call right after the creation.
     //If no options is found, it's not going to be sent to the API since undefined
     //properties are not encoded.
+    //NOTE: The `publish` property is set to true here because it is a part of the creation process and should provide a consistent flow.
     await client.updateFieldType({
       id: fieldPlugin.id,
       publish: true,

--- a/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/cli/src/commands/deploy/helper.ts
@@ -32,7 +32,7 @@ type UpsertFieldPluginFunc = (args: {
   packageName: string
   output: string
   skipPrompts: undefined | boolean
-  publish: undefined | boolean
+  publish: boolean
 }) => Promise<{ id: number }>
 
 type GetPackageName = (params: {
@@ -422,20 +422,16 @@ export const createFieldPlugin = async (
 // Publish Logic
 
 type CheckPublish = (params: {
-  publish: undefined | boolean
+  publish: boolean
   skipPrompts: undefined | boolean
 }) => Promise<boolean>
 
 export const checkPublish: CheckPublish = async ({ publish, skipPrompts }) => {
-  if (skipPrompts === true) {
-    //NOTE: Publish true is the default value
-    return publish || true
-  }
-
-  if (publish !== undefined) {
+  if (skipPrompts === true || publish === false) {
     return publish
   }
 
+  //NOTE: In interactive mode where --no-publish is not provided, the user is asked to confirm the publish action.
   const publishConfirmation = await confirmPublish()
   return publishConfirmation
 }

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -15,6 +15,7 @@ import { Scope } from '../../storyblok/storyblok-client'
 export type DeployArgs = {
   skipPrompts: boolean
   dir: string
+  publish: undefined | boolean
   name: undefined | string
   token: undefined | string
   output: undefined | string
@@ -25,7 +26,8 @@ export type DeployArgs = {
 type DeployFunc = (args: DeployArgs) => Promise<void>
 
 export const deploy: DeployFunc = async (params) => {
-  const { skipPrompts, token, name, dir, output, dotEnvPath, scope } = params
+  const { skipPrompts, token, name, dir, output, publish, dotEnvPath, scope } =
+    params
 
   console.log(bold(cyan('\nWelcome!')))
   console.log("Let's deploy a field-plugin.\n")
@@ -106,6 +108,7 @@ export const deploy: DeployFunc = async (params) => {
     token: personalAccessTokenResult.token,
     output: outputFile,
     scope: apiScope,
+    publish,
   })
 
   console.log(

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -15,7 +15,7 @@ import { Scope } from '../../storyblok/storyblok-client'
 export type DeployArgs = {
   skipPrompts: boolean
   dir: string
-  publish: undefined | boolean
+  publish: boolean
   name: undefined | string
   token: undefined | string
   output: undefined | string

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -60,6 +60,14 @@ export const createCLI = () => {
       '--name <value>',
       'name of plugin (Lowercase alphanumeric and dash)',
     )
+    .option(
+      '--publish',
+      'This flag is only applied when a plugin is being updated! Publishes a new version of the plugin.',
+    )
+    .option(
+      ' --no-publish',
+      'This flag is only applied when a plugin is being updated! Depending on the value it will only save or save and publish the new version of the plugin.',
+    )
     .addOption(
       new Option(
         '--output <value>',

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -65,7 +65,7 @@ export const createCLI = () => {
       'This flag is only applied when a plugin is being updated! Publishes a new version of the plugin.',
     )
     .option(
-      ' --no-publish',
+      '--no-publish',
       'This flag is only applied when a plugin is being updated! Uploads field plugin but does not publish a new version.',
     )
     .addOption(

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -61,10 +61,6 @@ export const createCLI = () => {
       'name of plugin (Lowercase alphanumeric and dash)',
     )
     .option(
-      '--publish',
-      'This flag is only applied when a plugin is being updated! Publishes a new version of the plugin.',
-    )
-    .option(
       '--no-publish',
       'This flag is only applied when a plugin is being updated! Uploads field plugin but does not publish a new version.',
     )

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -66,7 +66,7 @@ export const createCLI = () => {
     )
     .option(
       ' --no-publish',
-      'This flag is only applied when a plugin is being updated! Depending on the value it will only save or save and publish the new version of the plugin.',
+      'This flag is only applied when a plugin is being updated! Uploads field plugin but does not publish a new version.',
     )
     .addOption(
       new Option(


### PR DESCRIPTION
## What?
This PR adds a new flag to the deploy command for publishing a new version of field plugin during the update process.

### Context
As we have found out trough researching the APIs the POST request automatically publishes a field-plugin, therefore it is not possible to opt-out during the initial creations. However when using PUT method, updating the plugin, it is possible to send `publish` property, which will either only save the new plugin or save and publish it as a new version. 

### Deploy Command with `--no-publish` flag
Here are all the new test cases that are introduced by the change and are applied when a field plugin is updated. `

`yarn deploy --no-publish`

`yarn deploy --skipPrompts`

`yarn deploy --skipPrompts --no-publish`

## Why?
 #380

## How to test?

`yarn deploy`
--> NEW: User is prompted with the following question **Do you want to publish a new version of the field plugin?**
--> Depending on the user input the field plugin will be deployed

`yarn deploy --skipPrompts`
--> Plugin will be updated and published inside Storyblok.

`yarn deploy --no-publish` & `yarn deploy --skipPrompts --no-publish`
--> Plugin will be updated inside Storyblok but not published.
