### PR TITLE
feat(sandbox,lib,demo): modal in portal

### DIFF
--- a/packages/cli/templates/js/src/main.js
+++ b/packages/cli/templates/js/src/main.js
@@ -15,6 +15,7 @@ let previousType = 'loading'
 
 // Establish communication with the Visual Editor
 createFieldPlugin({
+  enablePortalModal: true,
   validateContent: (content) => ({
     content: typeof content === 'number' ? content : 0,
   }),

--- a/packages/cli/templates/react/src/components/FieldPlugin.tsx
+++ b/packages/cli/templates/react/src/components/FieldPlugin.tsx
@@ -3,6 +3,7 @@ import { useFieldPlugin } from '@storyblok/field-plugin/react'
 
 const FieldPlugin: FunctionComponent = () => {
   const plugin = useFieldPlugin({
+    enablePortalModal: true,
     /*
     The `validateContent` parameter is optional. It allows you to
       - validate the content

--- a/packages/cli/templates/react/src/components/FieldPluginExample/index.tsx
+++ b/packages/cli/templates/react/src/components/FieldPluginExample/index.tsx
@@ -7,6 +7,7 @@ import { useFieldPlugin } from '@storyblok/field-plugin/react'
 
 const FieldPlugin: FunctionComponent = () => {
   const { type, data, actions } = useFieldPlugin({
+    enablePortalModal: true,
     validateContent: (content: unknown) => ({
       content: typeof content === 'number' ? content : 0,
     }),

--- a/packages/cli/templates/vue2/src/fieldPlugin.js
+++ b/packages/cli/templates/vue2/src/fieldPlugin.js
@@ -4,6 +4,7 @@ import { createFieldPlugin } from '@storyblok/field-plugin'
 export const fieldPluginMixin = {
   created() {
     createFieldPlugin({
+      enablePortalModal: true,
       validateContent: (content) => ({
         content: typeof content === 'number' ? content : 0,
       }),

--- a/packages/cli/templates/vue3/src/components/FieldPlugin.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPlugin.vue
@@ -2,6 +2,7 @@
 import { useFieldPlugin } from '@storyblok/field-plugin/vue3'
 
 const plugin = useFieldPlugin({
+  enablePortalModal: true,
   /*
     The `validateContent` parameter is optional. It allows you to
       - validate the content

--- a/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
@@ -6,6 +6,7 @@ import AssetSelector from './AssetSelector.vue'
 import { useFieldPlugin } from '@storyblok/field-plugin/vue3'
 
 const plugin = useFieldPlugin({
+  enablePortalModal: true,
   validateContent: (content: unknown) => ({
     content: typeof content === 'number' ? content : 0,
   }),

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -19,7 +19,6 @@ export type PluginComponent = FunctionComponent<{
 export const FieldPluginDemo: FunctionComponent = () => {
   const { type, data, actions } = useFieldPlugin({
     validateContent,
-    targetOrigin: 'http://localhost:7070',
     enablePortalModal: true,
   })
 

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -19,6 +19,8 @@ export type PluginComponent = FunctionComponent<{
 export const FieldPluginDemo: FunctionComponent = () => {
   const { type, data, actions } = useFieldPlugin({
     validateContent,
+    targetOrigin: 'http://localhost:7070',
+    enablePortalModal: true,
   })
 
   if (type === 'loading') {

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -12,6 +12,7 @@ export type CreateFieldPluginOptions<Content> = {
   onUpdateState: (state: FieldPluginResponse<Content>) => void
   validateContent?: ValidateContent<Content>
   targetOrigin?: string
+  enablePortalModal?: boolean
 }
 
 export type CreateFieldPlugin = <Content = unknown>(
@@ -25,6 +26,7 @@ export const createFieldPlugin: CreateFieldPlugin = ({
   onUpdateState,
   validateContent,
   targetOrigin,
+  enablePortalModal,
 }) => {
   const isEmbedded = window.parent !== window
 
@@ -107,6 +109,7 @@ export const createFieldPlugin: CreateFieldPlugin = ({
     validateContent:
       validateContent ||
       ((content) => ({ content: content as InferredContent })),
+    enablePortalModal,
   })
 
   const cleanupHeightChangeListener = createHeightChangeListener(onHeightChange)

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -12,6 +12,7 @@ export type CreateFieldPluginOptions<Content> = {
   onUpdateState: (state: FieldPluginResponse<Content>) => void
   validateContent?: ValidateContent<Content>
   targetOrigin?: string
+//   TODO add enablePortalModal
 }
 
 export type CreateFieldPlugin = <Content = unknown>(

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -12,7 +12,6 @@ export type CreateFieldPluginOptions<Content> = {
   onUpdateState: (state: FieldPluginResponse<Content>) => void
   validateContent?: ValidateContent<Content>
   targetOrigin?: string
-//   TODO add enablePortalModal
 }
 
 export type CreateFieldPlugin = <Content = unknown>(

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -28,6 +28,7 @@ export type CreatePluginActions = <Content>(options: {
   postToContainer: (message: unknown) => void
   onUpdateState: (state: FieldPluginData<Content>) => void
   validateContent: ValidateContent<Content>
+  enablePortalModal: boolean | undefined
 }) => {
   // These functions are to be called by the field plugin when the user performs actions in the UI
   actions: FieldPluginActions<Content>
@@ -46,6 +47,7 @@ export const createPluginActions: CreatePluginActions = ({
   postToContainer,
   onUpdateState,
   validateContent,
+  enablePortalModal,
 }) => {
   const { pushCallback, popCallback } = callbackQueue()
 
@@ -143,7 +145,9 @@ export const createPluginActions: CreatePluginActions = ({
           resolve(pluginStateFromStateChangeMessage(message, validateContent)),
         )
         // Request the initial state from the Visual Editor.
-        postToContainer(pluginLoadedMessage({ uid, callbackId }))
+        postToContainer(
+          pluginLoadedMessage({ uid, callbackId, enablePortalModal }),
+        )
       })
     },
   }

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -28,7 +28,7 @@ export type CreatePluginActions = <Content>(options: {
   postToContainer: (message: unknown) => void
   onUpdateState: (state: FieldPluginData<Content>) => void
   validateContent: ValidateContent<Content>
-  enablePortalModal: boolean | undefined
+  enablePortalModal?: boolean
 }) => {
   // These functions are to be called by the field plugin when the user performs actions in the UI
   actions: FieldPluginActions<Content>

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
@@ -126,7 +126,6 @@ describe('PluginLoadedMessage', () => {
         expect(
           isPluginLoadedMessage({
             ...stub,
-            subscribeState: undefined,
           }),
         ).toEqual(true)
       })
@@ -134,34 +133,31 @@ describe('PluginLoadedMessage', () => {
         expect(
           isPluginLoadedMessage({
             ...stub,
-            subscribeState: true,
+            enablePortalModal: true,
           }),
         ).toEqual(true)
         expect(
           isPluginLoadedMessage({
             ...stub,
-            subscribeState: false,
+            enablePortalModal: false,
           }),
         ).toEqual(true)
-        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } =
-          stub
-        expect(isPluginLoadedMessage(subWithoutSubscribeState)).toEqual(true)
         expect(
           isPluginLoadedMessage({
             ...stub,
-            subscribeState: 'false',
+            enablePortalModal: 'false',
           }),
         ).toEqual(false)
         expect(
           isPluginLoadedMessage({
             ...stub,
-            subscribeState: 123,
+            enablePortalModal: 123,
           }),
         ).toEqual(false)
         expect(
           isPluginLoadedMessage({
             ...stub,
-            subscribeState: null,
+            enablePortalModal: null,
           }),
         ).toEqual(false)
       })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
@@ -120,7 +120,7 @@ describe('PluginLoadedMessage', () => {
         ).toEqual(false)
       })
     })
-    describe('usePortalModal', () => {
+    describe('enablePortalModal', () => {
       it('is optional', () => {
         expect(
           isPluginLoadedMessage({
@@ -184,9 +184,9 @@ describe('PluginLoadedMessage', () => {
         true,
       )
     })
-    it('sets usePortalModal to true', () => {
+    it('sets enablePortalModal to true', () => {
       expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
-        'usePortalModal',
+        'enablePortalModal',
         true,
       )
     })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
@@ -98,7 +98,8 @@ describe('PluginLoadedMessage', () => {
             subscribeState: false,
           }),
         ).toEqual(true)
-        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } = stub
+        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } =
+          stub
         expect(isPluginLoadedMessage(subWithoutSubscribeState)).toEqual(true)
         expect(
           isPluginLoadedMessage({
@@ -142,7 +143,8 @@ describe('PluginLoadedMessage', () => {
             subscribeState: false,
           }),
         ).toEqual(true)
-        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } = stub
+        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } =
+          stub
         expect(isPluginLoadedMessage(subWithoutSubscribeState)).toEqual(true)
         expect(
           isPluginLoadedMessage({
@@ -184,11 +186,21 @@ describe('PluginLoadedMessage', () => {
         true,
       )
     })
-    it('sets enablePortalModal to true', () => {
-      expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
+    it('does not define enablePortalModal by default', () => {
+      expect(pluginLoadedMessage({ uid, callbackId })).not.toHaveProperty(
         'enablePortalModal',
-        true,
       )
+    })
+    it('lets you define enablePortalModal', () => {
+      expect(
+        pluginLoadedMessage({ uid, callbackId, enablePortalModal: true }),
+      ).toHaveProperty('enablePortalModal', true)
+      expect(
+        pluginLoadedMessage({ uid, callbackId, enablePortalModal: false }),
+      ).toHaveProperty('enablePortalModal', false)
+      expect(
+        pluginLoadedMessage({ uid, callbackId, enablePortalModal: undefined }),
+      ).toHaveProperty('enablePortalModal', undefined)
     })
   })
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
@@ -76,6 +76,94 @@ describe('PluginLoadedMessage', () => {
         ).toEqual(false)
       })
     })
+    describe('subscribeState', () => {
+      it('is optional', () => {
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: undefined,
+          }),
+        ).toEqual(true)
+      })
+      it('is a boolean', () => {
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: true,
+          }),
+        ).toEqual(true)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: false,
+          }),
+        ).toEqual(true)
+        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } = stub
+        expect(isPluginLoadedMessage(subWithoutSubscribeState)).toEqual(true)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: 'false',
+          }),
+        ).toEqual(false)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: 123,
+          }),
+        ).toEqual(false)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: null,
+          }),
+        ).toEqual(false)
+      })
+    })
+    describe('usePortalModal', () => {
+      it('is optional', () => {
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: undefined,
+          }),
+        ).toEqual(true)
+      })
+      it('is a boolean', () => {
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: true,
+          }),
+        ).toEqual(true)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: false,
+          }),
+        ).toEqual(true)
+        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } = stub
+        expect(isPluginLoadedMessage(subWithoutSubscribeState)).toEqual(true)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: 'false',
+          }),
+        ).toEqual(false)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: 123,
+          }),
+        ).toEqual(false)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: null,
+          }),
+        ).toEqual(false)
+      })
+    })
   })
   describe('constructor', () => {
     it('includes the uid', () => {
@@ -87,6 +175,18 @@ describe('PluginLoadedMessage', () => {
     it('sets fullHeight to true', () => {
       expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
         'fullHeight',
+        true,
+      )
+    })
+    it('sets subscribeState to true', () => {
+      expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
+        'subscribeState',
+        true,
+      )
+    })
+    it('sets usePortalModal to true', () => {
+      expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
+        'usePortalModal',
         true,
       )
     })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
@@ -5,6 +5,7 @@ export type PluginLoadedMessage = MessageToContainer<'loaded'> & {
   // signals that the field plugin is responsible for its own scrolling in modal mode
   fullHeight?: boolean
   subscribeState?: boolean
+  usePortalModal?: boolean
 }
 export const isPluginLoadedMessage = (
   obj: unknown,
@@ -16,7 +17,10 @@ export const isPluginLoadedMessage = (
     typeof obj.fullHeight === 'boolean') &&
   (!hasKey(obj, 'subscribeState') ||
     typeof obj.subscribeState === 'undefined' ||
-    typeof obj.subscribeState === 'boolean')
+    typeof obj.subscribeState === 'boolean') &&
+  (!hasKey(obj, 'usePortalModal') ||
+    typeof obj.usePortalModal === 'undefined' ||
+    typeof obj.usePortalModal === 'boolean')
 
 export const pluginLoadedMessage = (
   options: Pick<PluginLoadedMessage, 'uid' | 'callbackId'>,
@@ -25,5 +29,6 @@ export const pluginLoadedMessage = (
   event: 'loaded',
   fullHeight: true,
   subscribeState: true,
+  usePortalModal: true,
   ...options,
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
@@ -23,12 +23,14 @@ export const isPluginLoadedMessage = (
     typeof obj.enablePortalModal === 'boolean')
 
 export const pluginLoadedMessage = (
-  options: Pick<PluginLoadedMessage, 'uid' | 'callbackId'>,
+  options: Pick<
+    PluginLoadedMessage,
+    'uid' | 'callbackId' | 'enablePortalModal'
+  >,
 ): PluginLoadedMessage => ({
   action: 'plugin-changed',
   event: 'loaded',
   fullHeight: true,
   subscribeState: true,
-  enablePortalModal: true,
   ...options,
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
@@ -5,7 +5,7 @@ export type PluginLoadedMessage = MessageToContainer<'loaded'> & {
   // signals that the field plugin is responsible for its own scrolling in modal mode
   fullHeight?: boolean
   subscribeState?: boolean
-  usePortalModal?: boolean
+  enablePortalModal?: boolean
 }
 export const isPluginLoadedMessage = (
   obj: unknown,
@@ -18,9 +18,9 @@ export const isPluginLoadedMessage = (
   (!hasKey(obj, 'subscribeState') ||
     typeof obj.subscribeState === 'undefined' ||
     typeof obj.subscribeState === 'boolean') &&
-  (!hasKey(obj, 'usePortalModal') ||
-    typeof obj.usePortalModal === 'undefined' ||
-    typeof obj.usePortalModal === 'boolean')
+  (!hasKey(obj, 'enablePortalModal') ||
+    typeof obj.enablePortalModal === 'undefined' ||
+    typeof obj.enablePortalModal === 'boolean')
 
 export const pluginLoadedMessage = (
   options: Pick<PluginLoadedMessage, 'uid' | 'callbackId'>,
@@ -29,6 +29,6 @@ export const pluginLoadedMessage = (
   event: 'loaded',
   fullHeight: true,
   subscribeState: true,
-  usePortalModal: true,
+  enablePortalModal: true,
   ...options,
 })

--- a/packages/sandbox/src/components/FieldPluginSandbox.tsx
+++ b/packages/sandbox/src/components/FieldPluginSandbox.tsx
@@ -108,6 +108,7 @@ const useSandbox = (
   const [isModalOpen, setModalOpen] = useState(false)
   const [height, setHeight] = useState(initialHeight)
   const [fullHeight, setFullHeight] = useState(false)
+  const [enablePortalModal, setEnablePortalModal] = useState(false)
   const [schema, setSchema] = useState<FieldPluginSchema>({
     field_type: 'preview',
     options: manifest.options,
@@ -218,6 +219,7 @@ const useSandbox = (
     (message: PluginLoadedMessage) => {
       setSubscribeState(Boolean(message.subscribeState))
       setFullHeight(Boolean(message.fullHeight))
+      setEnablePortalModal(Boolean(message.enablePortalModal))
       dispatchLoadedChanged({
         ...stateChangedData,
         action: 'loaded',
@@ -309,6 +311,7 @@ const useSandbox = (
       isModalOpen,
       height,
       fullHeight,
+      enablePortalModal,
       schema,
       url,
       fieldTypeIframe,
@@ -332,6 +335,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
       language,
       isModalOpen,
       fullHeight,
+      enablePortalModal,
       height,
       schema,
       url,
@@ -371,6 +375,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
               src={iframeSrc}
               height={height}
               isModal={isModalOpen}
+              enablePortalModal={enablePortalModal}
               fullHeight={fullHeight}
               ref={fieldTypeIframe}
             />

--- a/packages/sandbox/src/components/FieldPluginSandbox.tsx
+++ b/packages/sandbox/src/components/FieldPluginSandbox.tsx
@@ -65,6 +65,11 @@ const defaultManifest = { options: [] }
 const urlQueryParam = withDefault(StringParam, defaultUrl)
 const manifestQueryParam = withDefault(JsonParam, defaultManifest)
 
+export type ModalState =
+  | 'non-modal'
+  | 'modal-with-portal'
+  | 'modal-without-portal'
+
 const useSandbox = (
   onError: (message: { title: string; message?: string }) => void,
 ) => {
@@ -304,14 +309,23 @@ const useSandbox = (
     ],
   )
 
+  const modalState = useMemo<ModalState>(() => {
+    if (!isModalOpen) {
+      return 'non-modal'
+    } else if (enablePortalModal) {
+      return 'modal-with-portal'
+    } else {
+      return 'modal-without-portal'
+    }
+  }, [isModalOpen, enablePortalModal])
+
   return [
     {
       content,
       language,
-      isModalOpen,
       height,
       fullHeight,
-      enablePortalModal,
+      modalState,
       schema,
       url,
       fieldTypeIframe,
@@ -334,9 +348,8 @@ export const FieldPluginSandbox: FunctionComponent = () => {
     {
       content,
       language,
-      isModalOpen,
+      modalState,
       fullHeight,
-      enablePortalModal,
       height,
       schema,
       url,
@@ -375,8 +388,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
             <FieldTypePreview
               src={iframeSrc}
               height={height}
-              isModal={isModalOpen}
-              enablePortalModal={enablePortalModal}
+              modalState={modalState}
               fullHeight={fullHeight}
               ref={fieldTypeIframe}
               onModalChange={setModalOpen}
@@ -451,7 +463,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
             output={
               {
                 content,
-                isModalOpen,
+                isModalOpen: modalState !== 'non-modal',
                 translatable: schema.translatable,
                 storyLang: language,
                 options: recordFromFieldPluginOptions(schema.options),

--- a/packages/sandbox/src/components/FieldPluginSandbox.tsx
+++ b/packages/sandbox/src/components/FieldPluginSandbox.tsx
@@ -323,6 +323,7 @@ const useSandbox = (
       setSchema,
       setUrl,
       randomizeUid,
+      setModalOpen,
     },
   ] as const
 }
@@ -342,7 +343,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
       fieldTypeIframe,
       iframeSrc,
     },
-    { setContent, setLanguage, setSchema, setUrl, randomizeUid },
+    { setModalOpen, setContent, setLanguage, setSchema, setUrl, randomizeUid },
   ] = useSandbox(error)
 
   return (
@@ -378,6 +379,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
               enablePortalModal={enablePortalModal}
               fullHeight={fullHeight}
               ref={fieldTypeIframe}
+              onModalChange={setModalOpen}
             />
           </CenteredContent>
           <Stack alignSelf="flex-start">

--- a/packages/sandbox/src/components/FieldTypePreview.tsx
+++ b/packages/sandbox/src/components/FieldTypePreview.tsx
@@ -10,10 +10,12 @@ import {
   Backdrop,
   Box,
   Dialog,
+  IconButton,
   SxProps,
   Typography,
 } from '@mui/material'
 import { DisableShieldsNotification } from './DisableShieldsNotification'
+import { CloseIcon } from '@storyblok/mui'
 
 const NonPortalModal: FunctionComponent<
   PropsWithChildren<{
@@ -136,9 +138,11 @@ export const FieldTypePreview = forwardRef<
     // Allows the iframe to be refreshed
     iframeKey?: number
     sx?: SxProps
+    onModalChange: (isModal: boolean) => void
   }
 >(function FieldTypePreview(props, ref) {
-  const { height, isModal, fullHeight, enablePortalModal } = props
+  const { height, isModal, fullHeight, enablePortalModal, onModalChange } =
+    props
 
   const isNonPortalModalOpen = !enablePortalModal && isModal
   const isPortalModalOpen = enablePortalModal && isModal
@@ -152,6 +156,10 @@ export const FieldTypePreview = forwardRef<
     if (!isPortalModalOpen) {
       setRef(ref, el)
     }
+  }
+
+  const handleClose = () => {
+    onModalChange(false)
   }
 
   return (
@@ -169,7 +177,21 @@ export const FieldTypePreview = forwardRef<
             overflow: 'hidden',
           },
         }}
+        onClose={handleClose}
       >
+        <Box
+          width="100%"
+          display="flex"
+          justifyContent="flex-end"
+          padding={1}
+        >
+          <IconButton
+            onClick={handleClose}
+            color="secondary"
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
         <FieldPluginIframe
           key={props.iframeKey}
           src={props.src}

--- a/packages/sandbox/src/components/FieldTypePreview.tsx
+++ b/packages/sandbox/src/components/FieldTypePreview.tsx
@@ -9,14 +9,14 @@ import {
 } from '@mui/material'
 import { DisableShieldsNotification } from './DisableShieldsNotification'
 
-const FieldTypeModal: FunctionComponent<
+const NonPortalModal: FunctionComponent<
   PropsWithChildren<{
-    isModal: boolean
+    isNonPortalModalOpen: boolean
   }>
 > = (props) => (
   <Box
     sx={
-      props.isModal
+      props.isNonPortalModalOpen
         ? {
             position: 'fixed',
             left: 0,
@@ -38,12 +38,12 @@ const FieldTypeModal: FunctionComponent<
 
 const FieldTypeSandbox: FunctionComponent<
   PropsWithChildren<{
-    isModal: boolean
+    isNonPortalModalOpen: boolean
   }>
 > = (props) => (
   <Box
     sx={
-      props.isModal
+      props.isNonPortalModalOpen
         ? {
             bgcolor: 'background.paper',
             p: 6,
@@ -61,7 +61,7 @@ const FieldTypeSandbox: FunctionComponent<
     style={{
       display: 'flex',
       margin: 'auto',
-      width: props.isModal ? '90%' : '100%',
+      width: props.isNonPortalModalOpen ? '90%' : '100%',
     }}
   >
     {props.children}
@@ -74,13 +74,18 @@ export const FieldTypePreview = forwardRef<
     src: string | undefined
     height: number
     isModal: boolean
+    enablePortalModal: boolean
     fullHeight: boolean
     // Allows the iframe to be refreshed
     iframeKey?: number
     sx?: SxProps
   }
 >(function FieldTypePreview(props, ref) {
-  const { height, isModal, fullHeight } = props
+  const { height, isModal, fullHeight, enablePortalModal } = props
+
+  const isNonPortalModalOpen = !enablePortalModal && isModal
+  const isPortalModalOpen = enablePortalModal && isModal
+
   return (
     <Box sx={props.sx}>
       <DisableShieldsNotification />
@@ -88,8 +93,8 @@ export const FieldTypePreview = forwardRef<
         open={props.isModal}
         sx={{ zIndex: ({ zIndex }) => zIndex.drawer }}
       />
-      <FieldTypeModal isModal={props.isModal}>
-        <FieldTypeSandbox isModal={props.isModal}>
+      <NonPortalModal isNonPortalModalOpen={isNonPortalModalOpen}>
+        <FieldTypeSandbox isNonPortalModalOpen={isNonPortalModalOpen}>
           {typeof props.src !== 'undefined' ? (
             <Box
               ref={ref}
@@ -116,7 +121,7 @@ export const FieldTypePreview = forwardRef<
             </Alert>
           )}
         </FieldTypeSandbox>
-      </FieldTypeModal>
+      </NonPortalModal>
     </Box>
   )
 })


### PR DESCRIPTION
## What?

There is an issue that makes various elements on the screen overlap the field plugin modal:

![image](https://github.com/user-attachments/assets/67c73a08-248e-457e-a21a-152c5b1a34a2)

This happens because the field plugin is not using Teleport, but instead uses dynamic styling on its wrapping element to go from `position: relative` to `position: absolute`. But the iframe (and its wrapping div element) might very well not have the highest priority in its stacking context. The way this is normally solved in dialogs is to use `<Teleport>` to mount the element outside the stacking context, (somewhere next to the application root element).

However, this is not possible to implement without some kind of a breaking change: without the `Teleport`, the iframe element never remounts, which means that the plugin's application state is preserved between. transitions between modal and non-modal modes. But if we conditionally render it inside a `<Teleport>`, the iframe element is going to remount, which reset the plugin's application state. Some plugins persist their entire app state in the content—but not all, which is why this would be a breaking change.

Rather than making the breaking change in Storyfront, we are introducing an option `enablePortalModal` in `@storyblok/field-plugin` which is sent to Storyfront on initialization. This means that the clients will have to manually enable the flag to access this bug ifx. _This means that the bug with the overlapping element will persist for all existing field plugins until the authors upgrade and enable the new option._

### Changes

The solution is to include a new option `enablePortalModal` in the field-plugin SDK: when enabled, and when the field plugin loads, it will include a property `enablePortalModal: true` in the message to initialize. When set to `true`, the modal will be done with a `<Teleport>`, otherwise in the old way.

This value is then combined with the `isModal` state (which can be changed by the field plugin or the editor) into a derived value `modalState` that is in either of the following states: `'non-modal' | 'modal-with-portal' | 'modal-without-portal'`.

The option `enablePortalModal` is set to `true` in all templates.

## How to test?

#420 makes it more difficult to test. The sandbox preview won't work because it's not a whitelisted host. So you need to serve the sandbox and demo apps in local development, and update `packages/demo/src/components/FieldPluginDemo.tsx`:

```ts
  const { type, data, actions } = useFieldPlugin({
    validateContent,
    // Storyfront in local development mode
    // targetOrigin: 'http://localhost:3300',
    // Sandbox in local development mode:
    targetOrigin: 'http://localhost:7070',
  })
``` 

### Sandbox

In local development mode, you need change the demo application's `targetOrigib`:

`packages/demo/src/components/FieldPluginDemo.tsx`

```tsx
export const FieldPluginDemo: FunctionComponent = () => {
  const { type, data, actions } = useFieldPlugin({
    validateContent,
    targetOrigin: 'http://localhost:7070',
  })
```

Then either test with a plugin on the previous versions, or just comment out this line:

`packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts`:

The line `  enablePortalModal: true,` in

```ts
export const pluginLoadedMessage = (
  options: Pick<PluginLoadedMessage, 'uid' | 'callbackId'>,
): PluginLoadedMessage => ({
  action: 'plugin-changed',
  event: 'loaded',
  fullHeight: true,
  subscribeState: true,
  enablePortalModal: true,
  ...options,
})
```