### PR TITLE
fix(helper): effects are not cleaned up in @storyblok/field-plugin/react

### DIFF
--- a/packages/lib-helpers/react/src/useFieldPlugin.ts
+++ b/packages/lib-helpers/react/src/useFieldPlugin.ts
@@ -12,25 +12,27 @@ export const useFieldPlugin = <Content>(
     type: 'loading',
   })
 
-  useEffect(() => {
-    createFieldPlugin<Content>({
-      ...options,
-      onUpdateState: (state) => {
-        if (state.type === 'error') {
-          setPlugin({
-            type: 'error',
-            error: state.error,
-          })
-        } else if (state.type === 'loaded') {
-          setPlugin({
-            type: 'loaded',
-            data: state.data,
-            actions: state.actions,
-          })
-        }
-      },
-    })
-  }, [])
+  useEffect(
+    () =>
+      createFieldPlugin<Content>({
+        ...options,
+        onUpdateState: (state) => {
+          if (state.type === 'error') {
+            setPlugin({
+              type: 'error',
+              error: state.error,
+            })
+          } else if (state.type === 'loaded') {
+            setPlugin({
+              type: 'loaded',
+              data: state.data,
+              actions: state.actions,
+            })
+          }
+        },
+      }),
+    [],
+  )
 
   return plugin
 }


### PR DESCRIPTION
## What?

In `@storyblok/field-plugin/react`, the effects are not being cleaned up, because the cleanup function is not returned from the `useEffect` callback.

I also don't see any cleanup in the Vue 3 helper, but I am not addressing this in this PR. (SHAPE-7195)

## Why?

JIRA: SHAPE-7192

Effects must be cleaned up.

## How to test? (optional)

The demo app uses `@storyblok/field-plugin/react`:

1. Run `yarn workspace demo dev`
2. Open the sandbox https://plugin-sandbox.storyblok.com/field-plugin?url=http%3A%2F%2Flocalhost%3A8080%2F

The app should work normally. You don't normally notice the lack of cleanup, but in local development mode, you'd see the effects run at least twice, and possibly even more if you're modifying the helper itself.