### PR TITLE
fix(helper): clean up side effects in Vue 3 helper

### DIFF
--- a/packages/cli/templates/js/src/main.js
+++ b/packages/cli/templates/js/src/main.js
@@ -15,6 +15,7 @@ let previousType = 'loading'
 
 // Establish communication with the Visual Editor
 createFieldPlugin({
+  enablePortalModal: true,
   validateContent: (content) => ({
     content: typeof content === 'number' ? content : 0,
   }),

--- a/packages/cli/templates/react/src/components/FieldPlugin.tsx
+++ b/packages/cli/templates/react/src/components/FieldPlugin.tsx
@@ -3,6 +3,7 @@ import { useFieldPlugin } from '@storyblok/field-plugin/react'
 
 const FieldPlugin: FunctionComponent = () => {
   const plugin = useFieldPlugin({
+    enablePortalModal: true,
     /*
     The `validateContent` parameter is optional. It allows you to
       - validate the content

--- a/packages/cli/templates/react/src/components/FieldPluginExample/index.tsx
+++ b/packages/cli/templates/react/src/components/FieldPluginExample/index.tsx
@@ -7,6 +7,7 @@ import { useFieldPlugin } from '@storyblok/field-plugin/react'
 
 const FieldPlugin: FunctionComponent = () => {
   const { type, data, actions } = useFieldPlugin({
+    enablePortalModal: true,
     validateContent: (content: unknown) => ({
       content: typeof content === 'number' ? content : 0,
     }),

--- a/packages/cli/templates/vue2/src/fieldPlugin.js
+++ b/packages/cli/templates/vue2/src/fieldPlugin.js
@@ -4,6 +4,7 @@ import { createFieldPlugin } from '@storyblok/field-plugin'
 export const fieldPluginMixin = {
   created() {
     createFieldPlugin({
+      enablePortalModal: true,
       validateContent: (content) => ({
         content: typeof content === 'number' ? content : 0,
       }),

--- a/packages/cli/templates/vue3/src/components/FieldPlugin.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPlugin.vue
@@ -2,6 +2,7 @@
 import { useFieldPlugin } from '@storyblok/field-plugin/vue3'
 
 const plugin = useFieldPlugin({
+  enablePortalModal: true,
   /*
     The `validateContent` parameter is optional. It allows you to
       - validate the content

--- a/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
@@ -6,6 +6,7 @@ import AssetSelector from './AssetSelector.vue'
 import { useFieldPlugin } from '@storyblok/field-plugin/vue3'
 
 const plugin = useFieldPlugin({
+  enablePortalModal: true,
   validateContent: (content: unknown) => ({
     content: typeof content === 'number' ? content : 0,
   }),

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -19,7 +19,6 @@ export type PluginComponent = FunctionComponent<{
 export const FieldPluginDemo: FunctionComponent = () => {
   const { type, data, actions } = useFieldPlugin({
     validateContent,
-    targetOrigin: 'http://localhost:7070',
     enablePortalModal: true,
   })
 

--- a/packages/demo/src/components/FieldPluginDemo.tsx
+++ b/packages/demo/src/components/FieldPluginDemo.tsx
@@ -19,6 +19,8 @@ export type PluginComponent = FunctionComponent<{
 export const FieldPluginDemo: FunctionComponent = () => {
   const { type, data, actions } = useFieldPlugin({
     validateContent,
+    targetOrigin: 'http://localhost:7070',
+    enablePortalModal: true,
   })
 
   if (type === 'loading') {

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -12,6 +12,7 @@ export type CreateFieldPluginOptions<Content> = {
   onUpdateState: (state: FieldPluginResponse<Content>) => void
   validateContent?: ValidateContent<Content>
   targetOrigin?: string
+  enablePortalModal?: boolean
 }
 
 export type CreateFieldPlugin = <Content = unknown>(
@@ -25,6 +26,7 @@ export const createFieldPlugin: CreateFieldPlugin = ({
   onUpdateState,
   validateContent,
   targetOrigin,
+  enablePortalModal,
 }) => {
   const isEmbedded = window.parent !== window
 
@@ -107,6 +109,7 @@ export const createFieldPlugin: CreateFieldPlugin = ({
     validateContent:
       validateContent ||
       ((content) => ({ content: content as InferredContent })),
+    enablePortalModal,
   })
 
   const cleanupHeightChangeListener = createHeightChangeListener(onHeightChange)

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -12,6 +12,7 @@ export type CreateFieldPluginOptions<Content> = {
   onUpdateState: (state: FieldPluginResponse<Content>) => void
   validateContent?: ValidateContent<Content>
   targetOrigin?: string
+//   TODO add enablePortalModal
 }
 
 export type CreateFieldPlugin = <Content = unknown>(

--- a/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts
@@ -12,7 +12,6 @@ export type CreateFieldPluginOptions<Content> = {
   onUpdateState: (state: FieldPluginResponse<Content>) => void
   validateContent?: ValidateContent<Content>
   targetOrigin?: string
-//   TODO add enablePortalModal
 }
 
 export type CreateFieldPlugin = <Content = unknown>(

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -28,6 +28,7 @@ export type CreatePluginActions = <Content>(options: {
   postToContainer: (message: unknown) => void
   onUpdateState: (state: FieldPluginData<Content>) => void
   validateContent: ValidateContent<Content>
+  enablePortalModal: boolean | undefined
 }) => {
   // These functions are to be called by the field plugin when the user performs actions in the UI
   actions: FieldPluginActions<Content>
@@ -46,6 +47,7 @@ export const createPluginActions: CreatePluginActions = ({
   postToContainer,
   onUpdateState,
   validateContent,
+  enablePortalModal,
 }) => {
   const { pushCallback, popCallback } = callbackQueue()
 
@@ -143,7 +145,9 @@ export const createPluginActions: CreatePluginActions = ({
           resolve(pluginStateFromStateChangeMessage(message, validateContent)),
         )
         // Request the initial state from the Visual Editor.
-        postToContainer(pluginLoadedMessage({ uid, callbackId }))
+        postToContainer(
+          pluginLoadedMessage({ uid, callbackId, enablePortalModal }),
+        )
       })
     },
   }

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.ts
@@ -28,7 +28,7 @@ export type CreatePluginActions = <Content>(options: {
   postToContainer: (message: unknown) => void
   onUpdateState: (state: FieldPluginData<Content>) => void
   validateContent: ValidateContent<Content>
-  enablePortalModal: boolean | undefined
+  enablePortalModal?: boolean
 }) => {
   // These functions are to be called by the field plugin when the user performs actions in the UI
   actions: FieldPluginActions<Content>

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
@@ -120,7 +120,7 @@ describe('PluginLoadedMessage', () => {
         ).toEqual(false)
       })
     })
-    describe('usePortalModal', () => {
+    describe('enablePortalModal', () => {
       it('is optional', () => {
         expect(
           isPluginLoadedMessage({
@@ -184,9 +184,9 @@ describe('PluginLoadedMessage', () => {
         true,
       )
     })
-    it('sets usePortalModal to true', () => {
+    it('sets enablePortalModal to true', () => {
       expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
-        'usePortalModal',
+        'enablePortalModal',
         true,
       )
     })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
@@ -98,7 +98,8 @@ describe('PluginLoadedMessage', () => {
             subscribeState: false,
           }),
         ).toEqual(true)
-        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } = stub
+        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } =
+          stub
         expect(isPluginLoadedMessage(subWithoutSubscribeState)).toEqual(true)
         expect(
           isPluginLoadedMessage({
@@ -142,7 +143,8 @@ describe('PluginLoadedMessage', () => {
             subscribeState: false,
           }),
         ).toEqual(true)
-        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } = stub
+        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } =
+          stub
         expect(isPluginLoadedMessage(subWithoutSubscribeState)).toEqual(true)
         expect(
           isPluginLoadedMessage({
@@ -184,11 +186,21 @@ describe('PluginLoadedMessage', () => {
         true,
       )
     })
-    it('sets enablePortalModal to true', () => {
-      expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
+    it('does not define enablePortalModal by default', () => {
+      expect(pluginLoadedMessage({ uid, callbackId })).not.toHaveProperty(
         'enablePortalModal',
-        true,
       )
+    })
+    it('lets you define enablePortalModal', () => {
+      expect(
+        pluginLoadedMessage({ uid, callbackId, enablePortalModal: true }),
+      ).toHaveProperty('enablePortalModal', true)
+      expect(
+        pluginLoadedMessage({ uid, callbackId, enablePortalModal: false }),
+      ).toHaveProperty('enablePortalModal', false)
+      expect(
+        pluginLoadedMessage({ uid, callbackId, enablePortalModal: undefined }),
+      ).toHaveProperty('enablePortalModal', undefined)
     })
   })
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.test.ts
@@ -76,6 +76,94 @@ describe('PluginLoadedMessage', () => {
         ).toEqual(false)
       })
     })
+    describe('subscribeState', () => {
+      it('is optional', () => {
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: undefined,
+          }),
+        ).toEqual(true)
+      })
+      it('is a boolean', () => {
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: true,
+          }),
+        ).toEqual(true)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: false,
+          }),
+        ).toEqual(true)
+        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } = stub
+        expect(isPluginLoadedMessage(subWithoutSubscribeState)).toEqual(true)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: 'false',
+          }),
+        ).toEqual(false)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: 123,
+          }),
+        ).toEqual(false)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: null,
+          }),
+        ).toEqual(false)
+      })
+    })
+    describe('usePortalModal', () => {
+      it('is optional', () => {
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: undefined,
+          }),
+        ).toEqual(true)
+      })
+      it('is a boolean', () => {
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: true,
+          }),
+        ).toEqual(true)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: false,
+          }),
+        ).toEqual(true)
+        const { subscribeState: _subscribeState, ...subWithoutSubscribeState } = stub
+        expect(isPluginLoadedMessage(subWithoutSubscribeState)).toEqual(true)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: 'false',
+          }),
+        ).toEqual(false)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: 123,
+          }),
+        ).toEqual(false)
+        expect(
+          isPluginLoadedMessage({
+            ...stub,
+            subscribeState: null,
+          }),
+        ).toEqual(false)
+      })
+    })
   })
   describe('constructor', () => {
     it('includes the uid', () => {
@@ -87,6 +175,18 @@ describe('PluginLoadedMessage', () => {
     it('sets fullHeight to true', () => {
       expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
         'fullHeight',
+        true,
+      )
+    })
+    it('sets subscribeState to true', () => {
+      expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
+        'subscribeState',
+        true,
+      )
+    })
+    it('sets usePortalModal to true', () => {
+      expect(pluginLoadedMessage({ uid, callbackId })).toHaveProperty(
+        'usePortalModal',
         true,
       )
     })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
@@ -5,6 +5,7 @@ export type PluginLoadedMessage = MessageToContainer<'loaded'> & {
   // signals that the field plugin is responsible for its own scrolling in modal mode
   fullHeight?: boolean
   subscribeState?: boolean
+  usePortalModal?: boolean
 }
 export const isPluginLoadedMessage = (
   obj: unknown,
@@ -16,7 +17,10 @@ export const isPluginLoadedMessage = (
     typeof obj.fullHeight === 'boolean') &&
   (!hasKey(obj, 'subscribeState') ||
     typeof obj.subscribeState === 'undefined' ||
-    typeof obj.subscribeState === 'boolean')
+    typeof obj.subscribeState === 'boolean') &&
+  (!hasKey(obj, 'usePortalModal') ||
+    typeof obj.usePortalModal === 'undefined' ||
+    typeof obj.usePortalModal === 'boolean')
 
 export const pluginLoadedMessage = (
   options: Pick<PluginLoadedMessage, 'uid' | 'callbackId'>,
@@ -25,5 +29,6 @@ export const pluginLoadedMessage = (
   event: 'loaded',
   fullHeight: true,
   subscribeState: true,
+  usePortalModal: true,
   ...options,
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
@@ -23,12 +23,14 @@ export const isPluginLoadedMessage = (
     typeof obj.enablePortalModal === 'boolean')
 
 export const pluginLoadedMessage = (
-  options: Pick<PluginLoadedMessage, 'uid' | 'callbackId'>,
+  options: Pick<
+    PluginLoadedMessage,
+    'uid' | 'callbackId' | 'enablePortalModal'
+  >,
 ): PluginLoadedMessage => ({
   action: 'plugin-changed',
   event: 'loaded',
   fullHeight: true,
   subscribeState: true,
-  enablePortalModal: true,
   ...options,
 })

--- a/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/pluginToContainerMessage/PluginLoadedMessage.ts
@@ -5,7 +5,7 @@ export type PluginLoadedMessage = MessageToContainer<'loaded'> & {
   // signals that the field plugin is responsible for its own scrolling in modal mode
   fullHeight?: boolean
   subscribeState?: boolean
-  usePortalModal?: boolean
+  enablePortalModal?: boolean
 }
 export const isPluginLoadedMessage = (
   obj: unknown,
@@ -18,9 +18,9 @@ export const isPluginLoadedMessage = (
   (!hasKey(obj, 'subscribeState') ||
     typeof obj.subscribeState === 'undefined' ||
     typeof obj.subscribeState === 'boolean') &&
-  (!hasKey(obj, 'usePortalModal') ||
-    typeof obj.usePortalModal === 'undefined' ||
-    typeof obj.usePortalModal === 'boolean')
+  (!hasKey(obj, 'enablePortalModal') ||
+    typeof obj.enablePortalModal === 'undefined' ||
+    typeof obj.enablePortalModal === 'boolean')
 
 export const pluginLoadedMessage = (
   options: Pick<PluginLoadedMessage, 'uid' | 'callbackId'>,
@@ -29,6 +29,6 @@ export const pluginLoadedMessage = (
   event: 'loaded',
   fullHeight: true,
   subscribeState: true,
-  usePortalModal: true,
+  enablePortalModal: true,
   ...options,
 })

--- a/packages/lib-helpers/vue3/src/useFieldPlugin.ts
+++ b/packages/lib-helpers/vue3/src/useFieldPlugin.ts
@@ -4,7 +4,7 @@ import {
   FieldPluginData,
   FieldPluginResponse,
 } from '@storyblok/field-plugin'
-import { onMounted, reactive, UnwrapRef } from 'vue'
+import { onMounted, onUnmounted, reactive, UnwrapRef } from 'vue'
 import { convertToRaw } from './utils'
 
 const updateObjectWithoutChangingReference = (
@@ -28,8 +28,10 @@ export const useFieldPlugin = <Content>(
     type: 'loading',
   })
 
+  let cleanup: () => void = () => undefined
+
   onMounted(() => {
-    createFieldPlugin<Content>({
+    cleanup = createFieldPlugin<Content>({
       ...options,
       onUpdateState: (state) => {
         if (state.type === 'error') {
@@ -89,6 +91,8 @@ export const useFieldPlugin = <Content>(
       },
     })
   })
+
+  onUnmounted(cleanup)
 
   return plugin
 }

--- a/packages/sandbox/src/components/FieldPluginSandbox.tsx
+++ b/packages/sandbox/src/components/FieldPluginSandbox.tsx
@@ -108,6 +108,7 @@ const useSandbox = (
   const [isModalOpen, setModalOpen] = useState(false)
   const [height, setHeight] = useState(initialHeight)
   const [fullHeight, setFullHeight] = useState(false)
+  const [enablePortalModal, setEnablePortalModal] = useState(false)
   const [schema, setSchema] = useState<FieldPluginSchema>({
     field_type: 'preview',
     options: manifest.options,
@@ -218,6 +219,7 @@ const useSandbox = (
     (message: PluginLoadedMessage) => {
       setSubscribeState(Boolean(message.subscribeState))
       setFullHeight(Boolean(message.fullHeight))
+      setEnablePortalModal(Boolean(message.enablePortalModal))
       dispatchLoadedChanged({
         ...stateChangedData,
         action: 'loaded',
@@ -309,6 +311,7 @@ const useSandbox = (
       isModalOpen,
       height,
       fullHeight,
+      enablePortalModal,
       schema,
       url,
       fieldTypeIframe,
@@ -332,6 +335,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
       language,
       isModalOpen,
       fullHeight,
+      enablePortalModal,
       height,
       schema,
       url,
@@ -371,6 +375,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
               src={iframeSrc}
               height={height}
               isModal={isModalOpen}
+              enablePortalModal={enablePortalModal}
               fullHeight={fullHeight}
               ref={fieldTypeIframe}
             />

--- a/packages/sandbox/src/components/FieldPluginSandbox.tsx
+++ b/packages/sandbox/src/components/FieldPluginSandbox.tsx
@@ -65,6 +65,11 @@ const defaultManifest = { options: [] }
 const urlQueryParam = withDefault(StringParam, defaultUrl)
 const manifestQueryParam = withDefault(JsonParam, defaultManifest)
 
+export type ModalState =
+  | 'non-modal'
+  | 'modal-with-portal'
+  | 'modal-without-portal'
+
 const useSandbox = (
   onError: (message: { title: string; message?: string }) => void,
 ) => {
@@ -304,14 +309,23 @@ const useSandbox = (
     ],
   )
 
+  const modalState = useMemo<ModalState>(() => {
+    if (!isModalOpen) {
+      return 'non-modal'
+    } else if (enablePortalModal) {
+      return 'modal-with-portal'
+    } else {
+      return 'modal-without-portal'
+    }
+  }, [isModalOpen, enablePortalModal])
+
   return [
     {
       content,
       language,
-      isModalOpen,
       height,
       fullHeight,
-      enablePortalModal,
+      modalState,
       schema,
       url,
       fieldTypeIframe,
@@ -334,9 +348,8 @@ export const FieldPluginSandbox: FunctionComponent = () => {
     {
       content,
       language,
-      isModalOpen,
+      modalState,
       fullHeight,
-      enablePortalModal,
       height,
       schema,
       url,
@@ -375,8 +388,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
             <FieldTypePreview
               src={iframeSrc}
               height={height}
-              isModal={isModalOpen}
-              enablePortalModal={enablePortalModal}
+              modalState={modalState}
               fullHeight={fullHeight}
               ref={fieldTypeIframe}
               onModalChange={setModalOpen}
@@ -451,7 +463,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
             output={
               {
                 content,
-                isModalOpen,
+                isModalOpen: modalState !== 'non-modal',
                 translatable: schema.translatable,
                 storyLang: language,
                 options: recordFromFieldPluginOptions(schema.options),

--- a/packages/sandbox/src/components/FieldPluginSandbox.tsx
+++ b/packages/sandbox/src/components/FieldPluginSandbox.tsx
@@ -323,6 +323,7 @@ const useSandbox = (
       setSchema,
       setUrl,
       randomizeUid,
+      setModalOpen,
     },
   ] as const
 }
@@ -342,7 +343,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
       fieldTypeIframe,
       iframeSrc,
     },
-    { setContent, setLanguage, setSchema, setUrl, randomizeUid },
+    { setModalOpen, setContent, setLanguage, setSchema, setUrl, randomizeUid },
   ] = useSandbox(error)
 
   return (
@@ -378,6 +379,7 @@ export const FieldPluginSandbox: FunctionComponent = () => {
               enablePortalModal={enablePortalModal}
               fullHeight={fullHeight}
               ref={fieldTypeIframe}
+              onModalChange={setModalOpen}
             />
           </CenteredContent>
           <Stack alignSelf="flex-start">

--- a/packages/sandbox/src/components/FieldTypePreview.tsx
+++ b/packages/sandbox/src/components/FieldTypePreview.tsx
@@ -10,10 +10,12 @@ import {
   Backdrop,
   Box,
   Dialog,
+  IconButton,
   SxProps,
   Typography,
 } from '@mui/material'
 import { DisableShieldsNotification } from './DisableShieldsNotification'
+import { CloseIcon } from '@storyblok/mui'
 
 const NonPortalModal: FunctionComponent<
   PropsWithChildren<{
@@ -136,9 +138,11 @@ export const FieldTypePreview = forwardRef<
     // Allows the iframe to be refreshed
     iframeKey?: number
     sx?: SxProps
+    onModalChange: (isModal: boolean) => void
   }
 >(function FieldTypePreview(props, ref) {
-  const { height, isModal, fullHeight, enablePortalModal } = props
+  const { height, isModal, fullHeight, enablePortalModal, onModalChange } =
+    props
 
   const isNonPortalModalOpen = !enablePortalModal && isModal
   const isPortalModalOpen = enablePortalModal && isModal
@@ -152,6 +156,10 @@ export const FieldTypePreview = forwardRef<
     if (!isPortalModalOpen) {
       setRef(ref, el)
     }
+  }
+
+  const handleClose = () => {
+    onModalChange(false)
   }
 
   return (
@@ -169,7 +177,21 @@ export const FieldTypePreview = forwardRef<
             overflow: 'hidden',
           },
         }}
+        onClose={handleClose}
       >
+        <Box
+          width="100%"
+          display="flex"
+          justifyContent="flex-end"
+          padding={1}
+        >
+          <IconButton
+            onClick={handleClose}
+            color="secondary"
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
         <FieldPluginIframe
           key={props.iframeKey}
           src={props.src}

--- a/packages/sandbox/src/components/FieldTypePreview.tsx
+++ b/packages/sandbox/src/components/FieldTypePreview.tsx
@@ -9,14 +9,14 @@ import {
 } from '@mui/material'
 import { DisableShieldsNotification } from './DisableShieldsNotification'
 
-const FieldTypeModal: FunctionComponent<
+const NonPortalModal: FunctionComponent<
   PropsWithChildren<{
-    isModal: boolean
+    isNonPortalModalOpen: boolean
   }>
 > = (props) => (
   <Box
     sx={
-      props.isModal
+      props.isNonPortalModalOpen
         ? {
             position: 'fixed',
             left: 0,
@@ -38,12 +38,12 @@ const FieldTypeModal: FunctionComponent<
 
 const FieldTypeSandbox: FunctionComponent<
   PropsWithChildren<{
-    isModal: boolean
+    isNonPortalModalOpen: boolean
   }>
 > = (props) => (
   <Box
     sx={
-      props.isModal
+      props.isNonPortalModalOpen
         ? {
             bgcolor: 'background.paper',
             p: 6,
@@ -61,7 +61,7 @@ const FieldTypeSandbox: FunctionComponent<
     style={{
       display: 'flex',
       margin: 'auto',
-      width: props.isModal ? '90%' : '100%',
+      width: props.isNonPortalModalOpen ? '90%' : '100%',
     }}
   >
     {props.children}
@@ -74,13 +74,18 @@ export const FieldTypePreview = forwardRef<
     src: string | undefined
     height: number
     isModal: boolean
+    enablePortalModal: boolean
     fullHeight: boolean
     // Allows the iframe to be refreshed
     iframeKey?: number
     sx?: SxProps
   }
 >(function FieldTypePreview(props, ref) {
-  const { height, isModal, fullHeight } = props
+  const { height, isModal, fullHeight, enablePortalModal } = props
+
+  const isNonPortalModalOpen = !enablePortalModal && isModal
+  const isPortalModalOpen = enablePortalModal && isModal
+
   return (
     <Box sx={props.sx}>
       <DisableShieldsNotification />
@@ -88,8 +93,8 @@ export const FieldTypePreview = forwardRef<
         open={props.isModal}
         sx={{ zIndex: ({ zIndex }) => zIndex.drawer }}
       />
-      <FieldTypeModal isModal={props.isModal}>
-        <FieldTypeSandbox isModal={props.isModal}>
+      <NonPortalModal isNonPortalModalOpen={isNonPortalModalOpen}>
+        <FieldTypeSandbox isNonPortalModalOpen={isNonPortalModalOpen}>
           {typeof props.src !== 'undefined' ? (
             <Box
               ref={ref}
@@ -116,7 +121,7 @@ export const FieldTypePreview = forwardRef<
             </Alert>
           )}
         </FieldTypeSandbox>
-      </FieldTypeModal>
+      </NonPortalModal>
     </Box>
   )
 })


### PR DESCRIPTION

In the vue3 helper, side effects from `createFieldPlugin` are not being cleaned up.

If the application is never remounted, this is normally not a problem.

## How to test? (optional)

The Vue3 template should work as before.