### PR TITLE
fix(template): revert changes to templates

### DIFF
--- a/packages/cli/templates/js/src/main.js
+++ b/packages/cli/templates/js/src/main.js
@@ -15,7 +15,6 @@ let previousType = 'loading'
 
 // Establish communication with the Visual Editor
 createFieldPlugin({
-  enablePortalModal: true,
   validateContent: (content) => ({
     content: typeof content === 'number' ? content : 0,
   }),

--- a/packages/cli/templates/react/src/components/FieldPlugin.tsx
+++ b/packages/cli/templates/react/src/components/FieldPlugin.tsx
@@ -3,7 +3,6 @@ import { useFieldPlugin } from '@storyblok/field-plugin/react'
 
 const FieldPlugin: FunctionComponent = () => {
   const plugin = useFieldPlugin({
-    enablePortalModal: true,
     /*
     The `validateContent` parameter is optional. It allows you to
       - validate the content

--- a/packages/cli/templates/react/src/components/FieldPluginExample/index.tsx
+++ b/packages/cli/templates/react/src/components/FieldPluginExample/index.tsx
@@ -7,7 +7,6 @@ import { useFieldPlugin } from '@storyblok/field-plugin/react'
 
 const FieldPlugin: FunctionComponent = () => {
   const { type, data, actions } = useFieldPlugin({
-    enablePortalModal: true,
     validateContent: (content: unknown) => ({
       content: typeof content === 'number' ? content : 0,
     }),

--- a/packages/cli/templates/vue2/src/fieldPlugin.js
+++ b/packages/cli/templates/vue2/src/fieldPlugin.js
@@ -4,7 +4,6 @@ import { createFieldPlugin } from '@storyblok/field-plugin'
 export const fieldPluginMixin = {
   created() {
     createFieldPlugin({
-      enablePortalModal: true,
       validateContent: (content) => ({
         content: typeof content === 'number' ? content : 0,
       }),

--- a/packages/cli/templates/vue3/src/components/FieldPlugin.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPlugin.vue
@@ -2,7 +2,6 @@
 import { useFieldPlugin } from '@storyblok/field-plugin/vue3'
 
 const plugin = useFieldPlugin({
-  enablePortalModal: true,
   /*
     The `validateContent` parameter is optional. It allows you to
       - validate the content

--- a/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
+++ b/packages/cli/templates/vue3/src/components/FieldPluginExample/index.vue
@@ -6,7 +6,6 @@ import AssetSelector from './AssetSelector.vue'
 import { useFieldPlugin } from '@storyblok/field-plugin/vue3'
 
 const plugin = useFieldPlugin({
-  enablePortalModal: true,
   validateContent: (content: unknown) => ({
     content: typeof content === 'number' ? content : 0,
   }),


### PR DESCRIPTION
## What?

Revert changes to templates that introduced enablePortalModal
## Why?

To make the CI pass to publish the library, we need to be able to build the templates, but the templates are using the old version

The solution is to

1. revert the changes to the templates (this PR)
2. Publish the library
3. Add the changes back again
4. Publish the CLI

