### PR TITLE
chore(common): revert "fix the CI for checking if it is a library release"

### DIFF
--- a/.github/workflows/check-if-releasing-library.yml
+++ b/.github/workflows/check-if-releasing-library.yml
@@ -15,7 +15,7 @@ jobs:
         uses: jwalton/gh-find-current-pr@v1
       - id: validation
         run: |
-          if [[ "${{ steps.PR.outputs.title }}" == "chore(lib): release @storyblok/field-plugin@"* ]]; then
+          if [[ "${{ steps.PR.outputs.title }}" == "@storyblok/field-plugin@"* ]]; then
             echo "releasing library"
             echo "result=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Reverts storyblok/field-plugin#428

The same issue still occurs with dependabot updates.

I propose to go with the steps outlined in #427