### PR TITLE
ci(common): publish to NPM when you publish a draft release

### DIFF
--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -2,7 +2,7 @@ name: Publish CLI to NPM
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish-npm:

--- a/.github/workflows/npm-publish-library.yml
+++ b/.github/workflows/npm-publish-library.yml
@@ -2,7 +2,7 @@ name: Publish library to NPM
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish-npm:


### PR DESCRIPTION
When you open a draft release, the workflow does not trigger. 

See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release