### PR TITLE
chore(common): set MIT license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.storyblok.com/"
   },
   "private": true,
-  "license": "UNLICENSED",
+  "license": "MIT",
   "workspaces": [
     "packages/*",
     "packages/cli/templates/*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@storyblok/field-plugin-cli",
   "version": "1.4.0",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "field-plugin": "./bin.js"

--- a/packages/field-plugin/package.json
+++ b/packages/field-plugin/package.json
@@ -2,6 +2,7 @@
   "name": "@storyblok/field-plugin",
   "version": "1.4.0",
   "description": "SDK for creating Field Plugins for Storyblok.",
+  "license": "MIT",
   "sideEffects": false,
   "files": [
     "dist"


### PR DESCRIPTION
## What?

Set licenses in the package.json files so that it appears on NPM

![image](https://github.com/user-attachments/assets/454ce498-1e8a-47ff-bebf-2c10702d4c50)

