### PR TITLE
fix(lib): include userid to data response from field plugin

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
+++ b/packages/field-plugin/src/createFieldPlugin/FieldPluginData.ts
@@ -8,6 +8,7 @@ export type FieldPluginData<Content> = {
   content: Content
   options: Record<string, string>
   spaceId: number | undefined
+  userId: number | undefined
   interfaceLang: string
   storyLang: string
   story: StoryData

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginActions.test.ts
@@ -70,6 +70,7 @@ describe('createPluginActions', () => {
         interfaceLanguage: 'en',
         model: randomString,
         spaceId: null,
+        userId: undefined,
         blockId: undefined,
         releases: [],
         releaseId: undefined,

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/handlePluginMessage.test.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/createPluginMessageListener/handlePluginMessage.test.ts
@@ -60,6 +60,7 @@ describe('handlePluginMessage', () => {
       interfaceLanguage: 'en',
       model: 123,
       spaceId: 1234,
+      userId: 2345,
       story: { content: {} },
       schema: { options: [], field_type: 'avh', translatable: false },
       storyId: 1344,

--- a/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
+++ b/packages/field-plugin/src/createFieldPlugin/createPluginActions/partialPluginStateFromStateChangeMessage.ts
@@ -23,6 +23,7 @@ export const pluginStateFromStateChangeMessage = <Content>(
   return {
     interfaceLang: message.interfaceLanguage,
     spaceId: message.spaceId ?? undefined,
+    userId: message.userId ?? undefined,
     story: message.story ?? undefined,
     storyId: message.storyId ?? undefined,
     storyLang: message.language === '' ? 'default' : message.language,

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/LoadedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/LoadedMessage.test.ts
@@ -5,6 +5,7 @@ const stub: LoadedMessage = {
   action: 'loaded',
   uid: '-preview',
   spaceId: null,
+  userId: undefined,
   model: undefined,
   isModalOpen: false,
   token: null,

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/LoadedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/LoadedMessage.ts
@@ -34,6 +34,8 @@ export const isLoadedMessage = (data: unknown): data is LoadedMessage =>
   typeof data.language === 'string' &&
   hasKey(data, 'schema') &&
   isFieldPluginSchema(data.schema) &&
+  hasKey(data, 'userId') &&
+  (typeof data.userId === 'number' || typeof data.userId === 'undefined') &&
   hasKey(data, 'story') &&
   isStoryData(data.story) &&
   hasKey(data, 'isModalOpen') &&

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/LoadedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/LoadedMessage.ts
@@ -13,6 +13,7 @@ export type LoadedMessage = MessageToPlugin<'loaded'> & {
   language: string
   interfaceLanguage: string
   spaceId: number | null
+  userId: number | undefined
   story: StoryData
   storyId: number | undefined
   blockId: string | undefined

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.test.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.test.ts
@@ -1,8 +1,8 @@
-import { isLoadedMessage, LoadedMessage } from './LoadedMessage'
+import { isStateMessage, StateChangedMessage } from './StateChangedMessage'
 import { FieldPluginSchema } from './FieldPluginSchema'
 
-const stub: LoadedMessage = {
-  action: 'loaded',
+const stub: StateChangedMessage = {
+  action: 'state-changed',
   uid: '-preview',
   spaceId: null,
   userId: undefined,
@@ -19,14 +19,14 @@ const stub: LoadedMessage = {
   releaseId: undefined,
 }
 
-describe('LoadedMessage', () => {
+describe('StateChangedMessage', () => {
   it('should validate', () => {
-    expect(isLoadedMessage(stub)).toEqual(true)
+    expect(isStateMessage(stub)).toEqual(true)
   })
   describe('The "action" property', () => {
     it('equals "loaded"', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           action: 'anotherString',
         }),
@@ -36,7 +36,7 @@ describe('LoadedMessage', () => {
   describe('the "uid" property', () => {
     it('is a string', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           uid: 'anything',
         }),
@@ -44,7 +44,7 @@ describe('LoadedMessage', () => {
     })
     it('is not undefined', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           uid: undefined,
         }),
@@ -52,7 +52,7 @@ describe('LoadedMessage', () => {
     })
     it('is not null', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           uid: null,
         }),
@@ -60,7 +60,7 @@ describe('LoadedMessage', () => {
     })
     it('is not a number', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           uid: 123,
         }),
@@ -71,7 +71,7 @@ describe('LoadedMessage', () => {
   describe('the "language" property', () => {
     it('is a string', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           language: 'anything',
         }),
@@ -79,7 +79,7 @@ describe('LoadedMessage', () => {
     })
     it('is not undefined', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           language: undefined,
         }),
@@ -87,7 +87,7 @@ describe('LoadedMessage', () => {
     })
     it('is not null', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           language: null,
         }),
@@ -95,7 +95,7 @@ describe('LoadedMessage', () => {
     })
     it('is not a number', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           language: 123,
         }),
@@ -105,7 +105,7 @@ describe('LoadedMessage', () => {
   describe('The "schema" property', () => {
     it('is required', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           schema: undefined,
         }),
@@ -113,7 +113,7 @@ describe('LoadedMessage', () => {
     })
     it('must be a schema', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           schema: {
             field_type: 'my-field',
@@ -132,7 +132,7 @@ describe('LoadedMessage', () => {
   describe('The "userId" property', () => {
     it('is a number', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           userId: 123,
         }),
@@ -140,7 +140,7 @@ describe('LoadedMessage', () => {
     })
     it('is undefined', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           userId: undefined,
         }),
@@ -148,7 +148,7 @@ describe('LoadedMessage', () => {
     })
     it('is not null', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           userId: null,
         }),
@@ -156,7 +156,7 @@ describe('LoadedMessage', () => {
     })
     it('is not a string', () => {
       expect(
-        isLoadedMessage({
+        isStateMessage({
           ...stub,
           userId: '123',
         }),

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.ts
@@ -34,6 +34,8 @@ export const isStateMessage = (data: unknown): data is StateChangedMessage =>
   typeof data.language === 'string' &&
   hasKey(data, 'schema') &&
   isFieldPluginSchema(data.schema) &&
+  hasKey(data, 'userId') &&
+  (typeof data.userId === 'number' || typeof data.userId === 'undefined') &&
   hasKey(data, 'story') &&
   isStoryData(data.story) &&
   hasKey(data, 'isModalOpen') &&

--- a/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.ts
+++ b/packages/field-plugin/src/messaging/pluginMessage/containerToPluginMessage/StateChangedMessage.ts
@@ -13,6 +13,7 @@ export type StateChangedMessage = MessageToPlugin<'state-changed'> & {
   language: string
   interfaceLanguage: string
   spaceId: number | null
+  userId: number | undefined
   story: StoryData
   storyId: number | undefined
   blockId: string | undefined

--- a/packages/lib-helpers/test/src/index.ts
+++ b/packages/lib-helpers/test/src/index.ts
@@ -27,7 +27,7 @@ const getContainer = (sendToFieldPlugin: (data: unknown) => void) => {
   const language = 'default'
   const storyId = 'test-story-id'
   const spaceId = 'test-space-id'
-  const userId = 'test-user-id'
+  const userId = 1234
   const token = 'test-token'
   const story = {
     content: {},
@@ -142,6 +142,7 @@ export const setupFieldPlugin = () => {
         data: { callbackId: string } & Record<string, unknown>,
         origin: string,
       ) => {
+        console.log('postMessage', data, origin)
         container.receive({ data, origin })
       },
     ),

--- a/packages/lib-helpers/test/src/index.ts
+++ b/packages/lib-helpers/test/src/index.ts
@@ -27,6 +27,7 @@ const getContainer = (sendToFieldPlugin: (data: unknown) => void) => {
   const language = 'default'
   const storyId = 'test-story-id'
   const spaceId = 'test-space-id'
+  const userId = 'test-user-id'
   const token = 'test-token'
   const story = {
     content: {},
@@ -49,6 +50,7 @@ const getContainer = (sendToFieldPlugin: (data: unknown) => void) => {
     language,
     storyId,
     spaceId,
+    userId,
     token,
     action,
   })

--- a/packages/lib-helpers/test/src/index.ts
+++ b/packages/lib-helpers/test/src/index.ts
@@ -142,7 +142,6 @@ export const setupFieldPlugin = () => {
         data: { callbackId: string } & Record<string, unknown>,
         origin: string,
       ) => {
-        console.log('postMessage', data, origin)
         container.receive({ data, origin })
       },
     ),

--- a/packages/sandbox/src/components/FieldPluginSandbox.tsx
+++ b/packages/sandbox/src/components/FieldPluginSandbox.tsx
@@ -133,6 +133,7 @@ const useSandbox = (
       blockId: undefined,
       language,
       spaceId: null,
+      userId: undefined,
       story,
       storyId: undefined,
       token: null,


### PR DESCRIPTION
## What?
<!-- Mention the changes that are included in the PR -->

This PR includes the userID to the data response retrieved on state change and loaded state from a field plugin as documented within our [Field plugin API documentation](https://www.storyblok.com/docs/plugins/plugin-storyblok-mixin)

## Why?

JIRA: [SHAPE-7741](https://storyblok.atlassian.net/browse/SHAPE-7741)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->


## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

To test, run the following commands below (on separate terminals):

- `yarn dev:lib`.
- `yarn dev:demo`.
- `yarn dev:sandbox`.

These commands above should get your sandbox, field-plugin demo, and field-plugin library setup and running successfully.

Copy your currently running local sandbox URL, `http://localhost:7070/,` and place it within the file `packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts`.

<img width="600" alt="Screenshot 2024-12-03 at 12 56 39 PM" src="https://github.com/user-attachments/assets/6b7a8d78-e1de-41a6-b682-ad81700a4af0">

This facilitates communication between your sandbox and field plugin through the Iframe when interacting with the rendered Iframe window.

https://github.com/user-attachments/assets/30c84ddd-b684-401c-9810-23825b02ed90

You should find the userId property returned and other plugin-related data from your field plugin demo.

<img width="607" alt="Screenshot 2024-12-03 at 1 09 41 AM" src="https://github.com/user-attachments/assets/c38b9614-1171-42b6-bcf3-687de5131975">

[SHAPE-7741]: https://storyblok.atlassian.net/browse/SHAPE-7741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ