### PR TITLE
feat(sandbox): add copy and paste iframe permissions

### DIFF
--- a/packages/sandbox/src/components/FieldTypePreview.tsx
+++ b/packages/sandbox/src/components/FieldTypePreview.tsx
@@ -114,6 +114,7 @@ const FieldPluginIframe = forwardRef<
         flex: 1,
         border: 'none',
       }}
+      allow="clipboard-read; clipboard-write"
     />
   )
 })


### PR DESCRIPTION
## What?

<!-- Mention the changes that are included in the PR -->

This PR adds the permissions to allow copy/paste functionality from Plugins through the IFRAME.

## Why?

JIRA: [SHAPE-9838](https://storyblok.atlassian.net/browse/SHAPE-9838)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

![1](https://github.com/user-attachments/assets/307fa266-7394-4682-a6ff-cb6a982d6ae5)
![2](https://github.com/user-attachments/assets/0af384cd-f3af-44e9-9f6d-bd5d1afd2c87)

## How to test? (optional)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

1. Navigate to `packages/demo/src/components/FieldPluginDemo.tsx` and replace its contents with:

```
export const FieldPluginDemo: FunctionComponent = () => {
  return (
    <div>
      <button onClick={copyToClipboard}>
        Copy to Clipboard
      </button>
      Read Clipboard Text: {copiedText}
      <button onClick={readFromClipboard}>Read from Clipboard</button>
    </div>
  )
}

export const CopyToClipboard = () => {
  const copyToClipboard = () => {
    navigator.clipboard.writeText('Hello world').then(
      () => {
        console.log('Copying to clipboard was successful!')
      },
      (err) => {
        console.error('Could not copy text: ', err)
      },
    )
  }

  return (
    <button onClick={copyToClipboard}>
      Copy to Clipboard
    </button>
  )
}

const readFromClipboard = async () => {
    try {
      const text = await navigator.clipboard.readText()
      setCopiedText(text)
    } catch (err) {
      console.error('Failed to read clipboard contents: ', err)
    }
  }
```

2. In packages/field-plugin/src/createFieldPlugin/createFieldPlugin.ts, update the origin:

```
const origin = http://localhost:7070
```

Start the dev Storyfront-plugins servers in two terminals:

```
yarn dev:lib    # builds the field-plugin package
yarn dev:demo   # serves the demo app on http://localhost:8080
yarn dev:sandbox   # serves the sandbox app on http://localhost:7070
```

3. Navigate to localhost:7070 and ensure the copy and paste functionality is working as expected.


[SHAPE-9838]: https://storyblok.atlassian.net/browse/SHAPE-9838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ