### PR TITLE
fix: global styles get re-enabled when useFieldPlugin is called multiple times

### DIFF
--- a/packages/field-plugin/src/createFieldPlugin/disableDefaultStoryblokStyles.ts
+++ b/packages/field-plugin/src/createFieldPlugin/disableDefaultStoryblokStyles.ts
@@ -9,7 +9,5 @@ export const disableDefaultStoryblokStyles = (): (() => void) => {
 
   link?.setAttribute('disabled', '')
 
-  return () => {
-    link?.removeAttribute('disabled')
-  }
+  return () => {}
 }


### PR DESCRIPTION
## What?

`useFieldPlugin` calls `createFieldPlugin`, which disabled the global styles as a side effect. It also attempts to clean up the side effect by enabling the style sheet again. This means that when a component that calls `useFieldPlugin` unmounts, the cleanup function enables the style sheet again. But this causes an issue if there is still another component that was using this side effect:

1. Component A is rendered, and calls `useFieldPlugin`. The style sheet gets disabled.
2. Component B is rendered, and calls `useFieldPlugin`. The style sheet remains disabled.
3. Component B unmounts, so the cleanup function runs. The style sheet is re-enabled.
4. Component A is still mounted, but the style sheet is now enabled.

As a solution, I think we can simply skip removing the `disabled` attribute from the `style` element,

## How to test? (optional)
